### PR TITLE
Mars fetch functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,6 @@ Imports:
     rlang,
     rmarkdown,
     scales,
-    sp,
     tidyverse,
     ggtext,
     zoo,

--- a/R/mars_data_fetch_write_functions.R
+++ b/R/mars_data_fetch_write_functions.R
@@ -218,17 +218,14 @@ marsInterpolateBaro <- function(baro_psi, smp_id, weight, target_id){
 #'
 #' Return the day of the year, with hours and seconds as the decimal
 #'
-#' @param dtime_est POSIXct, format: "POSIXct, format: "YYYY-MM-DD HH:MM:SS""
+#' @param dtime POSIXct, format: "POSIXct, format: "YYYY-MM-DD HH:MM:SS""
 #' 
 #' @return Output with be a day with a decimal
 #' 
 #' @export
 
-
-
-yday_decimal <- function(dtime_est){
-
-  lubridate::yday(dtime_est) + lubridate::hour(dtime_est)/24 + lubridate::minute(dtime_est)/(24*60) + lubridate::second(dtime_est)/(24*60*60)
+yday_decimal <- function(dtime){
+  lubridate::yday(dtime) + lubridate::hour(dtime)/24 + lubridate::minute(dtime)/(24*60) + lubridate::second(dtime)/(24*60*60)
 }
 
 

--- a/R/mars_data_fetch_write_functions.R
+++ b/R/mars_data_fetch_write_functions.R
@@ -120,21 +120,21 @@ marsFetchRainfallData <- function(con, target_id, source = c("gage", "radar"), s
   
   rain_temp$rainfall_in %<>% as.numeric
   
-  rain_temp <- rain_temp |>
-    dplyr::mutate(dtime =  lubridate::force_tz(dtime, tz = "America/New_York"))
-  # # we need to reformat dates at midnight because ymd_hms does not know how to handle them
-  # # this is actually a base R issue, but it yyis still dumb
-  # # https://github.com/tidyverse/lubridate/issues/1124
-  rain_temp <- rain_temp |>
-    dplyr::mutate(dtime = lubridate::with_tz(dtime, tz = "EST"))
-  # #Apparently, attempting to set the time zone on a datetime that falls squarely on the spring forward datetime
-  # #Such as 2005-04-03 02:00:00
-  # #Returns NA, because the time is impossible.
-  # #I hate this so, so much
-  # #To mitigate this, we will strip NA values from the new object
-  # # rain_temp %<>% dplyr::filter(!is.na(dtime_edt)) %>% dplyr::arrange(dtime_edt)
-  rain_temp <- rain_temp |>
-    dplyr::filter(!is.na(dtime)) %>% dplyr::arrange(dtime)
+  rain_temp
+  # 
+  # rain_temp <- rain_temp |>
+  #   dplyr::mutate(dtime =  lubridate::force_tz(dtime, tz = "America/New_York"))
+  # # # we need to reformat dates at midnight because ymd_hms does not know how to handle them
+  # # # this is actually a base R issue, but it yyis still dumb
+  # # # https://github.com/tidyverse/lubridate/issues/1124
+  # # #Apparently, attempting to set the time zone on a datetime that falls squarely on the spring forward datetime
+  # # #Such as 2005-04-03 02:00:00
+  # # #Returns NA, because the time is impossible.
+  # # #I hate this so, so much
+  # # #To mitigate this, we will strip NA values from the new object
+  # # # rain_temp %<>% dplyr::filter(!is.na(dtime_edt)) %>% dplyr::arrange(dtime_edt)
+  # rain_temp <- rain_temp |>
+  #   dplyr::filter(!is.na(dtime)) %>% dplyr::arrange(dtime)
   
   #Our water level data is not corrected for daylight savings time. ie it doesn't spring forwards
   #So we must shift back any datetimes within the DST window
@@ -150,51 +150,51 @@ marsFetchRainfallData <- function(con, target_id, source = c("gage", "radar"), s
   # #If its greather than 30 minutes, we must insert a zero 15 minutes before B also
   # 
   # #First, create data frame to contain zero fills with same column names as our rain data
-  zeroFills <- rain_temp[0,]
-  #print("Begin zero-filling process")
-  for(i in 1:(nrow(rain_temp) - 1)){
-    # k <- difftime(rain_temp$dtime_edt[i+1], rain_temp$dtime_edt[i], units = "min")
-    k <- difftime(rain_temp$dtime[i+1], rain_temp$dtime[i], units = "min")
-    
-    #If gap is > 15 mins, put a zero 15 minutes after the gap starts
-    if(k > 15){
-      
-      
-      zeroFillIndex <- nrow(zeroFills)+1
-      
-      #Boundaries of the interval to be zeroed
-      boundary.low <- rain_temp$dtime[i]
-      boundary.high <- rain_temp$dtime[i+1]
-      # boundary.low <- rain_temp$dtime_edt[i]
-      # boundary.high <- rain_temp$dtime_edt[i+1]
-      
-      #The zero goes 15 minutes (900 seconds) after the first boundary
-      #Filled by index because R is weird about partially filled data frame rows
-      fill <- boundary.low + lubridate::seconds(900)
-      #these were causing several functions to crash. Need a way to index so this doesn't happen again.
-      zeroFills[zeroFillIndex, 5] <- fill                   #dtime_edt
-      zeroFills[zeroFillIndex, 3] <- 0                      #rainfall_in
-      zeroFills[zeroFillIndex, 2] <- rainsource   #gage_uid or radarcell_uid
-      # browser()
-      # print(paste("Gap-filling event ID. Before:", rain_temp$event[i], "After:", rain_temp$event[i+1]))
-      zeroFills[zeroFillIndex, 5] <- marsGapFillEventID(event_low = rain_temp[i, 5], event_high = rain_temp[i+1, 5]) #event
-      
-      #If the boundary is longer than 30 minutes, we need a second zero
-      if(k > 30){
-        
-        #This zero goes 15 minutes before the upper boundary
-        fill <- boundary.high - lubridate::seconds(900)
-        zeroFills[zeroFillIndex + 1, 2] <- fill                   #dtime_edt
-        zeroFills[zeroFillIndex + 1, 4] <- 0                      #rainfall_in
-        zeroFills[zeroFillIndex + 1, 3] <- rainsource   #gage_uid or radarcell_uid
-        
-        #print(paste("Gap-filling event ID. Before:", rain_temp[i, 5], "After:", rain_temp[i+1, 5]))
-        zeroFills[zeroFillIndex + 1, 5] <- marsGapFillEventID(event_low = rain_temp[i, 5], event_high = rain_temp[i+1, 5]) #event
-        
-      }
-      
-    }
-  }
+  # zeroFills <- rain_temp[0,]
+  # #print("Begin zero-filling process")
+  # for(i in 1:(nrow(rain_temp) - 1)){
+  #   # k <- difftime(rain_temp$dtime_edt[i+1], rain_temp$dtime_edt[i], units = "min")
+  #   k <- difftime(rain_temp$dtime[i+1], rain_temp$dtime[i], units = "min")
+  #   
+  #   #If gap is > 15 mins, put a zero 15 minutes after the gap starts
+  #   if(k > 15){
+  #     
+  #     
+  #     zeroFillIndex <- nrow(zeroFills)+1
+  #     
+  #     #Boundaries of the interval to be zeroed
+  #     boundary.low <- rain_temp$dtime[i]
+  #     boundary.high <- rain_temp$dtime[i+1]
+  #     # boundary.low <- rain_temp$dtime_edt[i]
+  #     # boundary.high <- rain_temp$dtime_edt[i+1]
+  #     
+  #     #The zero goes 15 minutes (900 seconds) after the first boundary
+  #     #Filled by index because R is weird about partially filled data frame rows
+  #     fill <- boundary.low + lubridate::seconds(900)
+  #     #these were causing several functions to crash. Need a way to index so this doesn't happen again.
+  #     zeroFills[zeroFillIndex, 5] <- fill                   #dtime_edt
+  #     zeroFills[zeroFillIndex, 3] <- 0                      #rainfall_in
+  #     zeroFills[zeroFillIndex, 2] <- rainsource   #gage_uid or radarcell_uid
+  #     # browser()
+  #     # print(paste("Gap-filling event ID. Before:", rain_temp$event[i], "After:", rain_temp$event[i+1]))
+  #     zeroFills[zeroFillIndex, 5] <- marsGapFillEventID(event_low = rain_temp[i, 5], event_high = rain_temp[i+1, 5]) #event
+  #     
+  #     #If the boundary is longer than 30 minutes, we need a second zero
+  #     if(k > 30){
+  #       
+  #       #This zero goes 15 minutes before the upper boundary
+  #       fill <- boundary.high - lubridate::seconds(900)
+  #       zeroFills[zeroFillIndex + 1, 2] <- fill                   #dtime_edt
+  #       zeroFills[zeroFillIndex + 1, 4] <- 0                      #rainfall_in
+  #       zeroFills[zeroFillIndex + 1, 3] <- rainsource   #gage_uid or radarcell_uid
+  #       
+  #       #print(paste("Gap-filling event ID. Before:", rain_temp[i, 5], "After:", rain_temp[i+1, 5]))
+  #       zeroFills[zeroFillIndex + 1, 5] <- marsGapFillEventID(event_low = rain_temp[i, 5], event_high = rain_temp[i+1, 5]) #event
+  #       
+  #     }
+  #     
+  #   }
+  # }
   #### No including because this causes more issues than it should
   # #Replace UIDs with SMP IDs
   # rainlocs <- DBI::dbGetQuery(con, paste0("SELECT * FROM ", rainparams$loctable))
@@ -208,8 +208,8 @@ marsFetchRainfallData <- function(con, target_id, source = c("gage", "radar"), s
   #   dplyr::arrange(dtime)
   # 
   # #round date to nearest minute
-  rain_temp <- rain_temp |>
-    dplyr::mutate(dtime = lubridate::round_date(dtime, "minute"))
+  # rain_temp <- rain_temp |>
+  #   dplyr::mutate(dtime = lubridate::round_date(dtime, "minute"))
   # 
   # #Rename dtime column if we are undoing daylight savings time
   # # if(daylightsavings == FALSE){
@@ -374,48 +374,49 @@ marsFetchBaroData <- function(con, target_id, start_date, end_date, data_interva
   if(!odbc::dbIsValid(con)){
     stop("Argument 'con' is not an open ODBC channel")
   }
-
-
+  
+  
   #Handle date Conversion
   start_date %<>% as.POSIXct(format = '%Y-%m-%d')
   end_date %<>% as.POSIXct(format = '%Y-%m-%d')
   
   #Get SMP locations, and the locations of the baro sensors
-  smp_loc <- odbc::dbGetQuery(con, "SELECT * FROM admin.tbl_smp_loc")
+  smp_loc <- DBI::dbGetQuery(con, "SELECT * FROM admin.tbl_smp_loc")
   locus_loc <- dplyr::filter(smp_loc, smp_id == target_id)
-  baro_smp <- odbc::dbGetQuery(con, "SELECT DISTINCT smp_id FROM admin.tbl_baro_rawfile;") %>% dplyr::pull(smp_id)
-
-  #Collect baro data
-  #Get all baro data for the specified time period
-  baro <- odbc::dbGetQuery(con, paste0("SELECT * FROM data.viw_barodata_smp b WHERE b.dtime_est >= '", start_date, "'", " AND b.dtime_est <= '", end_date + lubridate::days(1), "' order by dtime_est;"))
+  baro_smp <- DBI::dbGetQuery(con, "SELECT DISTINCT smp_id FROM admin.tbl_baro_rawfile;") %>% dplyr::pull(smp_id)
   
-  baro_latest_dtime <- odbc::dbGetQuery(con, paste0("SELECT max(dtime_est) FROM data.tbl_baro WHERE dtime_est < '", end_date + lubridate::days(1), "'")) %>% dplyr::pull()
-  baro_latest_valid <- odbc::dbGetQuery(con, paste0("SELECT max(dtime_est) FROM data.viw_barodata_neighbors WHERE neighbors >= 4 and dtime_est < '", end_date + lubridate::days(1), "'")) %>% dplyr::pull()
+  # #Collect baro data
+  # #Get all baro data for the specified time period
+  baro <- DBI::dbGetQuery(con, paste0("SELECT * FROM data.viw_barodata_smp WHERE dtime >= '", start_date, "'", " AND dtime <= '", end_date + lubridate::days(1), "' order by dtime;"))
+  # 
+  baro_latest_dtime <- odbc::dbGetQuery(con, paste0("SELECT max(dtime) FROM data.tbl_baro WHERE dtime < '", end_date + lubridate::days(1), "'")) %>% dplyr::pull()
+  baro_latest_valid <- odbc::dbGetQuery(con, paste0("SELECT max(dtime) FROM data.viw_barodata_neighbors WHERE neighbors >= 4 and dtime < '", end_date + lubridate::days(1), "'")) %>% dplyr::pull()
   
-  if(length(baro$dtime_est) == 0){
+  if(length(baro$dtime) == 0){
     stop (paste0("No data available in the reqested interval. The latest available baro data is from ", baro_latest_dtime, "."))
   }
   
   #this is a seperate pipe so that it could be stopped before the error
-  needs_thickening <- baro$dtime_est %>% lubridate::second() %>% {. > 0} %>% any() == TRUE
+  needs_thickening <- baro$dtime %>% lubridate::second() %>% {. > 0} %>% any() == TRUE
   if(needs_thickening == TRUE){
-    baro %<>% padr::thicken(interval = "5 mins", rounding = "down") %>% 
-      dplyr::group_by(dtime_est_5_min, smp_id) %>% 
-      dplyr::summarize(baro_psi = max(baro_psi, na.rm = TRUE)) %>% 
-      dplyr::select(dtime_est = dtime_est_5_min, smp_id, baro_psi) %>% 
+    baro %<>% padr::thicken(interval = "5 mins", rounding = "down") %>%
+      dplyr::group_by(dtime_5_min, smp_id) %>%
+      dplyr::summarize(baro_psi = max(baro_psi, na.rm = TRUE)) %>%
+      dplyr::select(dtime = dtime_5_min, smp_id, baro_psi) %>%
       dplyr::ungroup()
   }else{
-    baro %<>% dplyr::group_by(dtime_est, smp_id) %>% 
-      dplyr::summarize(baro_psi = max(baro_psi, na.rm = TRUE)) %>% 
-      dplyr::select(dtime_est, smp_id, baro_psi) %>% 
+    baro %<>% dplyr::group_by(dtime, smp_id) %>%
+      dplyr::summarize(baro_psi = max(baro_psi, na.rm = TRUE)) %>%
+      dplyr::select(dtime, smp_id, baro_psi) %>%
       dplyr::ungroup()
   }
   
-  baro$dtime_est %<>% lubridate::force_tz(tz = "EST")
+  baro$dtime %<>% lubridate::with_tz(tz = "EST")
+  baro
   
-  #initialize countNAs_t in case the loop doesn't run. It is passed as a param to markdown so it needs to exist. 
-  countNAs_t <- 0 
-
+  #initialize countNAs_t in case the loop doesn't run. It is passed as a param to markdown so it needs to exist.
+  countNAs_t <- 0
+  
   #When the user requests data at a 5-minute resolution, we need to stretch our 15-minute data into 5-minute data
   #We can use tidyr::spread and padr::pad to generate the full 5 minute time series,
   #And then use zoo::na.locf (last observation carried forward) to fill the NAs with the most recent value
@@ -427,7 +428,7 @@ marsFetchBaroData <- function(con, target_id, start_date, end_date, data_interva
     
     #Pad installs 5 minute intervals in our 15 minute dtime_est column. All other columns become NA
     #End value is 10 minutes after the final period because that 15 minute data point is good for 10 more minutes
-    baro_pad <- padr::pad(baro, start_val = min(baro$dtime_est), end_val = max(baro$dtime_est) + lubridate::minutes(10), interval = "5 mins")
+    baro_pad <- padr::pad(baro, start_val = min(baro$dtimet), end_val = max(baro$dtime) + lubridate::minutes(10), interval = "5 mins")
     
     #To count the LOCF operations, we count the NAs in the data frame before and after the LOCF
     countNAs <- baro_pad[1,]
@@ -437,13 +438,14 @@ marsFetchBaroData <- function(con, target_id, start_date, end_date, data_interva
       countNAs[,i] <- countNAs[,i]- sum(is.na(baro_pad[,i])) #subtract remaining NAs to get number of NAs filled
     }
     
-    countNAs %<>% dplyr::select(-dtime_est)
+    countNAs %<>% dplyr::select(-dtime)
     countNAs_t <- countNAs %>% t() %>% data.frame() %>% tibble::rownames_to_column() %>%  magrittr::set_colnames(c("Location", "No. of LOCFs"))
     
     #Return baro data to long data format
-    baro <- tidyr::gather(baro_pad, "smp_id", "baro_psi", -dtime_est) %>%
+    baro <- tidyr::gather(baro_pad, "smp_id", "baro_psi", -dtime) %>%
       dplyr::filter(!is.na(baro_psi))
   }
+  baro
   
   #Calculate the distance between every baro location and the target SMP, then add weight
   baro_weights <- dplyr::filter(smp_loc, smp_id %in% baro_smp) %>%
@@ -458,100 +460,100 @@ marsFetchBaroData <- function(con, target_id, start_date, end_date, data_interva
   baro_weights$weight <- replace(baro_weights$weight, baro_weights$weight > 1000, 1000)
   
   interpolated_baro <- dplyr::left_join(baro, baro_weights, by = "smp_id") %>% #join baro and weights
-    dplyr::group_by(dtime_est) %>% #group datetimes, then calculate weighting effect for each datetime
+    dplyr::group_by(dtime) %>% #group datetimes, then calculate weighting effect for each datetime
     dplyr::summarize(baro_psi = marsInterpolateBaro(baro_psi, smp_id, weight, target_id),
                      smp_id =  "Interpolated",
-                     neighbors = dplyr::n()) %>% 
+                     neighbors = dplyr::n()) %>%
     zoo::na.trim(sides = "right") #trim trailing NAs
-  
-  #Initialize Final Series
-  finalseries <- interpolated_baro
-  
-  
-  #Give 5 or 15 minute data as appropriate
-  if(data_interval == "15 mins"){
-    clippedseries <- data.frame(dtime_est = seq.POSIXt(from = start_date, to = end_date + lubridate::days(1), by = data_interval) )
-    
-    finalseries <- dplyr::filter(finalseries, dtime_est %in% clippedseries$dtime_est)
-    baro <- dplyr::filter(baro, dtime_est %in% clippedseries$dtime_est)
-  }
-  
-  
-  #Adding "neighbor" counts and instances to report
-  neighbors <- dplyr::group_by(finalseries, neighbors) %>%
-    dplyr::summarize(count = dplyr::n()) %>%
-    magrittr::set_colnames(c("Neighbors", "Count"))
-  
-  ##finalseries is now ready, but return() must happen after plot and markdown are created
-  
-  #Baro Raster Plot
-  #Get elevations #This has been removed in favor of using distances to sort SMPs on plot. Code is left in case 
-  #baro_elev <- odbc::dbGetQuery(con, "SELECT * FROM smp_elev") %>% filter(smp_id %in% baro$smp_id)
-  
-  #currently disabled (2/2/21)
-  
-  # #Bind all raw baro data with interpolated data, and add weights
-  # baro_p <- dplyr::bind_rows(baro, finalseries)
-  # baro_p <- dplyr::left_join(baro_p, baro_weights, by = "smp_id") 
   # 
-  # #Set NA weights to max weight +1 so interpolated data plots at the top of the chart
-  # baro_p$weight[is.na(baro_p$weight)] <- max(baro_p$weight)+1
-  # 
-  # #Sort SMP IDs by elevation
-  # baro_p$smp_id <- factor(baro_p$smp_id, levels = unique(baro_p$smp_id[order(baro_p$weight)]))
-  # 
-  # #Add year and day for chart
-  # baro_p %<>% dplyr::mutate("day" = yday_decimal(baro_p$dtime_est),
-  #                    "year" = lubridate::year(baro_p$dtime_est))
+  # #Initialize Final Series
+  # finalseries <- interpolated_baro
   # 
   # 
-  # baro_p$smp_id %<>% as.factor
+  # #Give 5 or 15 minute data as appropriate
+  # if(data_interval == "15 mins"){
+  #   clippedseries <- data.frame(dtime_est = seq.POSIXt(from = start_date, to = end_date + lubridate::days(1), by = data_interval) )
+  #   
+  #   finalseries <- dplyr::filter(finalseries, dtime_est %in% clippedseries$dtime_est)
+  #   baro <- dplyr::filter(baro, dtime_est %in% clippedseries$dtime_est)
+  # }
   # 
-  # #Create baro Raster Chart
-  # p <- marsBaroRasterPlot(baro_p)
-  
-  
-  #Create baro Map
-  # baro_loc <- smp_loc %>% dplyr::filter(smp_id %in% baro$smp_id)
-  # rownames(baro_loc) <- NULL
-  # coords <- baro_loc[c("lon_wgs84", "lat_wgs84")]
-  # baro_sp <- sp::SpatialPointsDataFrame(coords, data = baro_loc, proj4string = sp::CRS("+proj=longlat +datum=WGS84 +ellps=WGS84 +towgs84=0,0,0"))
-  # coords <- locus_loc[c("lon_wgs84", "lat_wgs84")]
-  # smp_sp <- sp::SpatialPointsDataFrame(coords, data = locus_loc, proj4string = sp::CRS("+proj=longlat +datum=WGS84 +ellps=WGS84 +towgs84=0,0,0"))
-  # baro_map <- mapview::mapview(baro_sp, layer.name = "Baro") + mapview::mapview(smp_sp, color = "red", col.regions = NA, layer.name = "Target SMP")
   # 
-  downloader_folder <- "O:/Watershed Sciences/GSI Monitoring/07 Databases and Tracking Spreadsheets/13 MARS Analysis Database/Scripts/Downloader/Baro Data Downloader"
-  # downloader_folder_csv <- "\\\\\\\\pwdoows\\\\oows\\\\Watershed Sciences\\\\GSI Monitoring\\07 Databases and Tracking Spreadsheets\\13 MARS Analysis Database\\\\Scripts\\\\Downloader\\\\Baro Data Downloader\\\\"
+  # #Adding "neighbor" counts and instances to report
+  # neighbors <- dplyr::group_by(finalseries, neighbors) %>%
+  #   dplyr::summarize(count = dplyr::n()) %>%
+  #   magrittr::set_colnames(c("Neighbors", "Count"))
   # 
-  #render markdown document
-  #output file and output dir arguments do not work, so file is placed where markdown document is, and moved later
-  
-  #markdown is currently disabled
-  
-  # rmarkdown::render(system.file("rmd", "baro.rmd", package = "pwdgsi"), #find .rmd location on local cpu
-  #                   params = list(smp_id = target_id,  #input parameters to be passed into markdown body
-  #                                 start_date = start_date,
-  #                                 end_date = end_date,
-  #                                 data_interval = data_interval,
-  #                                 neighbors = neighbors,
-  #                                 countNAs = countNAs_t,
-  #                                 p = p,
-  #                                 map = baro_map,
-  #                                 baro_latest_dtime = baro_latest_dtime,
-  #                                 baro_latest_valid = baro_latest_valid))
-
-  # #give a new filename and path
-  # new_filename <- paste0(downloader_folder, "/Reports/", paste(target_id, start_date, "to", end_date, sep = "_"), "_baro_report.html")
+  # ##finalseries is now ready, but return() must happen after plot and markdown are created
   # 
-  # #move file to Baro Data Downloader/Reports folder
-  # file.rename(from = paste0(system.file("rmd", "baro.html", package = "pwdgsi")),
-  #             to = new_filename)
+  # #Baro Raster Plot
+  # #Get elevations #This has been removed in favor of using distances to sort SMPs on plot. Code is left in case 
+  # #baro_elev <- odbc::dbGetQuery(con, "SELECT * FROM smp_elev") %>% filter(smp_id %in% baro$smp_id)
   # 
-  # #open html
-  # browseURL(new_filename)
-  
-  #return Final Series. 
-  return(finalseries)
+  # #currently disabled (2/2/21)
+  # 
+  # # #Bind all raw baro data with interpolated data, and add weights
+  # # baro_p <- dplyr::bind_rows(baro, finalseries)
+  # # baro_p <- dplyr::left_join(baro_p, baro_weights, by = "smp_id") 
+  # # 
+  # # #Set NA weights to max weight +1 so interpolated data plots at the top of the chart
+  # # baro_p$weight[is.na(baro_p$weight)] <- max(baro_p$weight)+1
+  # # 
+  # # #Sort SMP IDs by elevation
+  # # baro_p$smp_id <- factor(baro_p$smp_id, levels = unique(baro_p$smp_id[order(baro_p$weight)]))
+  # # 
+  # # #Add year and day for chart
+  # # baro_p %<>% dplyr::mutate("day" = yday_decimal(baro_p$dtime_est),
+  # #                    "year" = lubridate::year(baro_p$dtime_est))
+  # # 
+  # # 
+  # # baro_p$smp_id %<>% as.factor
+  # # 
+  # # #Create baro Raster Chart
+  # # p <- marsBaroRasterPlot(baro_p)
+  # 
+  # 
+  # #Create baro Map
+  # # baro_loc <- smp_loc %>% dplyr::filter(smp_id %in% baro$smp_id)
+  # # rownames(baro_loc) <- NULL
+  # # coords <- baro_loc[c("lon_wgs84", "lat_wgs84")]
+  # # baro_sp <- sp::SpatialPointsDataFrame(coords, data = baro_loc, proj4string = sp::CRS("+proj=longlat +datum=WGS84 +ellps=WGS84 +towgs84=0,0,0"))
+  # # coords <- locus_loc[c("lon_wgs84", "lat_wgs84")]
+  # # smp_sp <- sp::SpatialPointsDataFrame(coords, data = locus_loc, proj4string = sp::CRS("+proj=longlat +datum=WGS84 +ellps=WGS84 +towgs84=0,0,0"))
+  # # baro_map <- mapview::mapview(baro_sp, layer.name = "Baro") + mapview::mapview(smp_sp, color = "red", col.regions = NA, layer.name = "Target SMP")
+  # # 
+  # downloader_folder <- "O:/Watershed Sciences/GSI Monitoring/07 Databases and Tracking Spreadsheets/13 MARS Analysis Database/Scripts/Downloader/Baro Data Downloader"
+  # # downloader_folder_csv <- "\\\\\\\\pwdoows\\\\oows\\\\Watershed Sciences\\\\GSI Monitoring\\07 Databases and Tracking Spreadsheets\\13 MARS Analysis Database\\\\Scripts\\\\Downloader\\\\Baro Data Downloader\\\\"
+  # # 
+  # #render markdown document
+  # #output file and output dir arguments do not work, so file is placed where markdown document is, and moved later
+  # 
+  # #markdown is currently disabled
+  # 
+  # # rmarkdown::render(system.file("rmd", "baro.rmd", package = "pwdgsi"), #find .rmd location on local cpu
+  # #                   params = list(smp_id = target_id,  #input parameters to be passed into markdown body
+  # #                                 start_date = start_date,
+  # #                                 end_date = end_date,
+  # #                                 data_interval = data_interval,
+  # #                                 neighbors = neighbors,
+  # #                                 countNAs = countNAs_t,
+  # #                                 p = p,
+  # #                                 map = baro_map,
+  # #                                 baro_latest_dtime = baro_latest_dtime,
+  # #                                 baro_latest_valid = baro_latest_valid))
+  # 
+  # # #give a new filename and path
+  # # new_filename <- paste0(downloader_folder, "/Reports/", paste(target_id, start_date, "to", end_date, sep = "_"), "_baro_report.html")
+  # # 
+  # # #move file to Baro Data Downloader/Reports folder
+  # # file.rename(from = paste0(system.file("rmd", "baro.html", package = "pwdgsi")),
+  # #             to = new_filename)
+  # # 
+  # # #open html
+  # # browseURL(new_filename)
+  # 
+  # #return Final Series. 
+  # return(finalseries)
   
 }
 

--- a/R/mars_data_fetch_write_functions.R
+++ b/R/mars_data_fetch_write_functions.R
@@ -826,7 +826,7 @@ marsFetchSMPSnapshot <- function(con, smp_id, ow_suffix, request_date){
 #'
 #' Returns a data frame with requested SMP water level data
 #'   
-#' @param con An ODBC connection to the MARS Analysis database returned by odbc::dbConnect
+#' @param con An connection to the MARS Analysis database returned
 #' @param target_id vector of chr, SMP ID, where the user has requested data
 #' @param ow_suffix vector of chr, SMP ID, where the user has requested data
 #' @param start_date string, format: "YYYY-MM-DD", start of data request range
@@ -836,7 +836,7 @@ marsFetchSMPSnapshot <- function(con, smp_id, ow_suffix, request_date){
 #' @return Output will be a dataframe with the following columns: 
 #' 
 #'     \item{ow_leveldata_uid}{int}
-#'     \item{dtime_est}{POSIXct datetime}
+#'     \item{dtime}{POSIXct datetime in America/New_York}
 #'     \item{level_ft}{num, recorded water level in feet}
 #'     \item{ow_uid}{num, ow_uid derived from smp_id and ow_suffix} 
 #'     
@@ -845,9 +845,7 @@ marsFetchSMPSnapshot <- function(con, smp_id, ow_suffix, request_date){
 #' @seealso \code{\link{marsFetchRainfallData}}, \code{\link{marsFetchRainEventData}}, \code{\link{marsFetchMonitoringData}}
 #' 
 marsFetchLevelData <- function(con, target_id, ow_suffix, start_date, end_date, sump_correct){
-  
-  #1 Argument Validation
-  #1.1 Check database connection
+  # Check DB connection
   if(!odbc::dbIsValid(con)){
     stop("Argument 'con' is not an open ODBC channel")
   }
@@ -858,35 +856,35 @@ marsFetchLevelData <- function(con, target_id, ow_suffix, start_date, end_date, 
   validity_query <- paste0("select * from fieldwork.fun_get_ow_uid('",target_id,"','",ow_suffix,"', NULL)")
   ow_uid <- odbc::dbGetQuery(con, validity_query)
   
-  #1.3 check if data exists in viw will have a sump. Change sump_correct to FALSE if necessary
-  
-  
-  #1.4 Pick which table to query
-  if(stringr::str_replace(ow_suffix, ".$", "") %in% c("CW", "GW", "PZ")){
-    level_table <- "data.tbl_gw_depthdata_raw"
-  }else if(!(stringr::str_replace(ow_suffix, ".$", "") %in% c("CW", "GW", "PZ")) & sump_correct == TRUE){
-    level_table <- "data.viw_ow_leveldata_sumpcorrected"
-  }else if(!(stringr::str_replace(ow_suffix, ".$", "") %in% c("CW", "GW", "PZ")) & sump_correct == FALSE){
-    level_table <- "data.tbl_ow_leveldata_raw"
-  }
-  start_date %<>% as.POSIXct(format = '%Y-%m-%d')
-  end_date %<>% as.POSIXct(format = '%Y-%m-%d')
-  
-  #1.5 Add buffer to requested dates
-  start_date <- lubridate::round_date(start_date) - lubridate::days(1)
-  end_date <- lubridate::round_date(end_date) + lubridate::days(1)
-  
-  #2 Query database for level data
-  leveldata_query <- paste0("select * from ", level_table, "
-                                WHERE ow_uid = '", ow_uid, "'
-                                AND dtime_est BETWEEN '",start_date,"' AND '", end_date, "'")
-  
-  leveldata <- odbc::dbGetQuery(con, leveldata_query) %>% dplyr::arrange(dtime_est)
-  
-  leveldata$dtime_est %<>% lubridate::force_tz(tz = "EST") %>% lubridate::round_date("minute")
-  
-  #3 Return level data
-  return(leveldata)
+  # #1.3 check if data exists in viw will have a sump. Change sump_correct to FALSE if necessary
+  # 
+  # 
+  # #1.4 Pick which table to query
+  # if(stringr::str_replace(ow_suffix, ".$", "") %in% c("CW", "GW", "PZ")){
+  #   level_table <- "data.tbl_gw_depthdata_raw"
+  # }else if(!(stringr::str_replace(ow_suffix, ".$", "") %in% c("CW", "GW", "PZ")) & sump_correct == TRUE){
+  #   level_table <- "data.viw_ow_leveldata_sumpcorrected"
+  # }else if(!(stringr::str_replace(ow_suffix, ".$", "") %in% c("CW", "GW", "PZ")) & sump_correct == FALSE){
+  #   level_table <- "data.tbl_ow_leveldata_raw"
+  # }
+  # start_date %<>% as.POSIXct(format = '%Y-%m-%d')
+  # end_date %<>% as.POSIXct(format = '%Y-%m-%d')
+  # 
+  # #1.5 Add buffer to requested dates
+  # start_date <- lubridate::round_date(start_date) - lubridate::days(1)
+  # end_date <- lubridate::round_date(end_date) + lubridate::days(1)
+  # 
+  # #2 Query database for level data
+  # leveldata_query <- paste0("select * from ", level_table, "
+  #                               WHERE ow_uid = '", ow_uid, "'
+  #                               AND dtime_est BETWEEN '",start_date,"' AND '", end_date, "'")
+  # 
+  # leveldata <- odbc::dbGetQuery(con, leveldata_query) %>% dplyr::arrange(dtime_est)
+  # 
+  # leveldata$dtime_est %<>% lubridate::force_tz(tz = "EST") %>% lubridate::round_date("minute")
+  # 
+  # #3 Return level data
+  # return(leveldata)
 }
 
 # marsFetchRainEventData --------------------------------

--- a/R/mars_data_fetch_write_functions.R
+++ b/R/mars_data_fetch_write_functions.R
@@ -418,7 +418,7 @@ marsFetchBaroData <- function(con, target_id, start_date, end_date, data_interva
 
     #Pad installs 5 minute intervals in our 15 minute dtime_est column. All other columns become NA
     #End value is 10 minutes after the final period because that 15 minute data point is good for 10 more minutes
-    baro_pad <- padr::pad(baro, start_val = min(baro$dtimet), end_val = max(baro$dtime) + lubridate::minutes(10), interval = "5 mins")
+    baro_pad <- padr::pad(baro, start_val = min(baro$dtime), end_val = max(baro$dtime) + lubridate::minutes(10), interval = "5 mins")
 
     #To count the LOCF operations, we count the NAs in the data frame before and after the LOCF
     countNAs <- baro_pad[1,]
@@ -452,95 +452,6 @@ marsFetchBaroData <- function(con, target_id, start_date, end_date, data_interva
                      smp_id =  "Interpolated",
                      neighbors = dplyr::n()) %>%
     zoo::na.trim(sides = "right") #trim trailing NAs
-
-  # #Initialize Final Series
-  # finalseries <- interpolated_baro
-
-
-  # #Give 5 or 15 minute data as appropriate
-  # if(data_interval == "15 mins"){
-  #   clippedseries <- data.frame(dtime_est = seq.POSIXt(from = start_date, to = end_date + lubridate::days(1), by = data_interval) )
-  # 
-  #   finalseries <- dplyr::filter(finalseries, dtime_est %in% clippedseries$dtime_est)
-  #   baro <- dplyr::filter(baro, dtime_est %in% clippedseries$dtime_est)
-  # }
-
-  # 
-  # #Adding "neighbor" counts and instances to report
-  # neighbors <- dplyr::group_by(finalseries, neighbors) %>%
-  #   dplyr::summarize(count = dplyr::n()) %>%
-  #   magrittr::set_colnames(c("Neighbors", "Count"))
-  # 
-  # ##finalseries is now ready, but return() must happen after plot and markdown are created
-  # 
-  # #Baro Raster Plot
-  # #Get elevations #This has been removed in favor of using distances to sort SMPs on plot. Code is left in case 
-  # #baro_elev <- odbc::dbGetQuery(con, "SELECT * FROM smp_elev") %>% filter(smp_id %in% baro$smp_id)
-  # 
-  # #currently disabled (2/2/21)
-  # 
-  # # #Bind all raw baro data with interpolated data, and add weights
-  # # baro_p <- dplyr::bind_rows(baro, finalseries)
-  # # baro_p <- dplyr::left_join(baro_p, baro_weights, by = "smp_id") 
-  # # 
-  # # #Set NA weights to max weight +1 so interpolated data plots at the top of the chart
-  # # baro_p$weight[is.na(baro_p$weight)] <- max(baro_p$weight)+1
-  # # 
-  # # #Sort SMP IDs by elevation
-  # # baro_p$smp_id <- factor(baro_p$smp_id, levels = unique(baro_p$smp_id[order(baro_p$weight)]))
-  # # 
-  # # #Add year and day for chart
-  # # baro_p %<>% dplyr::mutate("day" = yday_decimal(baro_p$dtime_est),
-  # #                    "year" = lubridate::year(baro_p$dtime_est))
-  # # 
-  # # 
-  # # baro_p$smp_id %<>% as.factor
-  # # 
-  # # #Create baro Raster Chart
-  # # p <- marsBaroRasterPlot(baro_p)
-  # 
-  # 
-  # #Create baro Map
-  # # baro_loc <- smp_loc %>% dplyr::filter(smp_id %in% baro$smp_id)
-  # # rownames(baro_loc) <- NULL
-  # # coords <- baro_loc[c("lon_wgs84", "lat_wgs84")]
-  # # baro_sp <- sp::SpatialPointsDataFrame(coords, data = baro_loc, proj4string = sp::CRS("+proj=longlat +datum=WGS84 +ellps=WGS84 +towgs84=0,0,0"))
-  # # coords <- locus_loc[c("lon_wgs84", "lat_wgs84")]
-  # # smp_sp <- sp::SpatialPointsDataFrame(coords, data = locus_loc, proj4string = sp::CRS("+proj=longlat +datum=WGS84 +ellps=WGS84 +towgs84=0,0,0"))
-  # # baro_map <- mapview::mapview(baro_sp, layer.name = "Baro") + mapview::mapview(smp_sp, color = "red", col.regions = NA, layer.name = "Target SMP")
-  # # 
-  # downloader_folder <- "O:/Watershed Sciences/GSI Monitoring/07 Databases and Tracking Spreadsheets/13 MARS Analysis Database/Scripts/Downloader/Baro Data Downloader"
-  # # downloader_folder_csv <- "\\\\\\\\pwdoows\\\\oows\\\\Watershed Sciences\\\\GSI Monitoring\\07 Databases and Tracking Spreadsheets\\13 MARS Analysis Database\\\\Scripts\\\\Downloader\\\\Baro Data Downloader\\\\"
-  # # 
-  # #render markdown document
-  # #output file and output dir arguments do not work, so file is placed where markdown document is, and moved later
-  # 
-  # #markdown is currently disabled
-  # 
-  # # rmarkdown::render(system.file("rmd", "baro.rmd", package = "pwdgsi"), #find .rmd location on local cpu
-  # #                   params = list(smp_id = target_id,  #input parameters to be passed into markdown body
-  # #                                 start_date = start_date,
-  # #                                 end_date = end_date,
-  # #                                 data_interval = data_interval,
-  # #                                 neighbors = neighbors,
-  # #                                 countNAs = countNAs_t,
-  # #                                 p = p,
-  # #                                 map = baro_map,
-  # #                                 baro_latest_dtime = baro_latest_dtime,
-  # #                                 baro_latest_valid = baro_latest_valid))
-  # 
-  # # #give a new filename and path
-  # # new_filename <- paste0(downloader_folder, "/Reports/", paste(target_id, start_date, "to", end_date, sep = "_"), "_baro_report.html")
-  # # 
-  # # #move file to Baro Data Downloader/Reports folder
-  # # file.rename(from = paste0(system.file("rmd", "baro.html", package = "pwdgsi")),
-  # #             to = new_filename)
-  # # 
-  # # #open html
-  # # browseURL(new_filename)
-  # 
-  # #return Final Series. 
-  # return(finalseries)
   
 }
 
@@ -882,11 +793,6 @@ marsFetchLevelData <- function(con, target_id, ow_suffix, start_date, end_date, 
   leveldata <- DBI::dbGetQuery(con, leveldata_query) %>% dplyr::arrange(dtime) 
   leveldata <- leveldata |> 
     dplyr::mutate(dtime = lubridate::round_date(dtime, "minute"))
-  # 
-  # leveldata$dtime_est %<>% lubridate::force_tz(tz = "EST") %>% lubridate::round_date("minute")
-  # 
-  # #3 Return level data
-  # return(leveldata)
 }
 
 # marsFetchRainEventData --------------------------------
@@ -953,14 +859,6 @@ marsFetchRainEventData <- function(con, target_id, source = c("gage", "radar"), 
                        "AND eventdataend <= Date('", end_date + lubridate::days(1), "');")
   
   events <- odbc::dbGetQuery(con, event_query) 
-  # # making this "EST"
-  # events %<>% dplyr::mutate(eventdatastart_est = lubridate::force_tz(eventdatastart_edt,"EST"))
-  # events %<>% dplyr::mutate(eventdataend_est = lubridate::force_tz(eventdataend_edt,"EST"))
-  # events %<>% dplyr::select(-eventdatastart_edt,
-  #                    -eventdataend_edt)
-  # 
-  # #3 return event data
-  # return(events)
 }
 
 # marsFetchMonitoringData --------------------------------

--- a/R/mars_data_fetch_write_functions.R
+++ b/R/mars_data_fetch_write_functions.R
@@ -226,6 +226,7 @@ marsInterpolateBaro <- function(baro_psi, smp_id, weight, target_id){
 
 yday_decimal <- function(dtime){
   lubridate::yday(dtime) + lubridate::hour(dtime)/24 + lubridate::minute(dtime)/(24*60) + lubridate::second(dtime)/(24*60*60)
+  #### Does not include POSIXct types
 }
 
 

--- a/R/old_baro.R
+++ b/R/old_baro.R
@@ -1,0 +1,187 @@
+old_baro <- function(con, target_id, start_date, end_date, data_interval = c("5 mins", "15 mins")){
+  if(!odbc::dbIsValid(con)){
+    stop("Argument 'con' is not an open ODBC channel")
+  }
+  
+  
+  #Handle date Conversion
+  start_date %<>% as.POSIXct(format = '%Y-%m-%d')
+  end_date %<>% as.POSIXct(format = '%Y-%m-%d')
+  
+  #Get SMP locations, and the locations of the baro sensors
+  smp_loc <- odbc::dbGetQuery(con, "SELECT * FROM admin.tbl_smp_loc")
+  locus_loc <- dplyr::filter(smp_loc, smp_id == target_id)
+  baro_smp <- odbc::dbGetQuery(con, "SELECT DISTINCT smp_id FROM admin.tbl_baro_rawfile;") %>% dplyr::pull(smp_id)
+
+  #Collect baro data
+  #Get all baro data for the specified time period
+  baro <- odbc::dbGetQuery(con, paste0("SELECT * FROM data.viw_barodata_smp b WHERE b.dtime_est >= '", start_date, "'", " AND b.dtime_est <= '", end_date + lubridate::days(1), "' order by dtime_est;"))
+
+  baro_latest_dtime <- odbc::dbGetQuery(con, paste0("SELECT max(dtime_est) FROM data.tbl_baro WHERE dtime_est < '", end_date + lubridate::days(1), "'")) %>% dplyr::pull()
+  baro_latest_valid <- odbc::dbGetQuery(con, paste0("SELECT max(dtime_est) FROM data.viw_barodata_neighbors WHERE neighbors >= 4 and dtime_est < '", end_date + lubridate::days(1), "'")) %>% dplyr::pull()
+
+  if(length(baro$dtime_est) == 0){
+    stop (paste0("No data available in the reqested interval. The latest available baro data is from ", baro_latest_dtime, "."))
+  }
+
+  #this is a seperate pipe so that it could be stopped before the error
+  needs_thickening <- baro$dtime_est %>% lubridate::second() %>% {. > 0} %>% any() == TRUE
+  if(needs_thickening == TRUE){
+    baro %<>% padr::thicken(interval = "5 mins", rounding = "down") %>%
+      dplyr::group_by(dtime_est_5_min, smp_id) %>%
+      dplyr::summarize(baro_psi = max(baro_psi, na.rm = TRUE)) %>%
+      dplyr::select(dtime_est = dtime_est_5_min, smp_id, baro_psi) %>%
+      dplyr::ungroup()
+  }else{
+    baro %<>% dplyr::group_by(dtime_est, smp_id) %>%
+      dplyr::summarize(baro_psi = max(baro_psi, na.rm = TRUE)) %>%
+      dplyr::select(dtime_est, smp_id, baro_psi) %>%
+      dplyr::ungroup()
+  }
+
+
+  baro$dtime_est %<>% lubridate::force_tz(tz = "EST")
+  baro
+
+  #initialize countNAs_t in case the loop doesn't run. It is passed as a param to markdown so it needs to exist.
+  countNAs_t <- 0
+
+  #When the user requests data at a 5-minute resolution, we need to stretch our 15-minute data into 5-minute data
+  #We can use tidyr::spread and padr::pad to generate the full 5 minute time series,
+  #And then use zoo::na.locf (last observation carried forward) to fill the NAs with the most recent value
+  if(data_interval == "5 mins"){
+
+    #Spread data to have all baro measurements use the same dtime_est column
+    #So we can pad every 15-minute time series at once
+    baro <- tidyr::spread(baro, "smp_id", "baro_psi")
+
+    #Pad installs 5 minute intervals in our 15 minute dtime_est column. All other columns become NA
+    #End value is 10 minutes after the final period because that 15 minute data point is good for 10 more minutes
+    baro_pad <- padr::pad(baro, start_val = min(baro$dtime_est), end_val = max(baro$dtime_est) + lubridate::minutes(10), interval = "5 mins")
+
+    #To count the LOCF operations, we count the NAs in the data frame before and after the LOCF
+    countNAs <- baro_pad[1,]
+    for(i in 2:ncol(baro_pad)){
+      countNAs[,i] <- sum(is.na(baro_pad[,i])) #count NAs before they are filled
+      baro_pad[,i] <- zoo::na.locf(baro_pad[,i], maxgap = 2, na.rm = FALSE) #maxgap = 2 means only fill NAs created by the pad
+      countNAs[,i] <- countNAs[,i]- sum(is.na(baro_pad[,i])) #subtract remaining NAs to get number of NAs filled
+    }
+
+    countNAs %<>% dplyr::select(-dtime_est)
+    countNAs_t <- countNAs %>% t() %>% data.frame() %>% tibble::rownames_to_column() %>%  magrittr::set_colnames(c("Location", "No. of LOCFs"))
+
+    #Return baro data to long data format
+    baro <- tidyr::gather(baro_pad, "smp_id", "baro_psi", -dtime_est) %>%
+      dplyr::filter(!is.na(baro_psi))
+  }
+  baro
+
+  #Calculate the distance between every baro location and the target SMP, then add weight
+  baro_weights <- dplyr::filter(smp_loc, smp_id %in% baro_smp) %>%
+    dplyr::mutate(lon_dist = lon_wgs84 - locus_loc$lon_wgs84,
+                  lat_dist = lat_wgs84 - locus_loc$lat_wgs84,
+                  dist_total = sqrt(lon_dist**2 + lat_dist**2)) %>%
+    dplyr::mutate(weight = 1/dist_total) %>% #inverse distance weight with power = 1
+    dplyr::select(smp_id, weight) %>%
+    dplyr::arrange(smp_id)
+
+  #Cap weight at 1000
+  baro_weights$weight <- replace(baro_weights$weight, baro_weights$weight > 1000, 1000)
+
+  interpolated_baro <- dplyr::left_join(baro, baro_weights, by = "smp_id") %>% #join baro and weights
+    dplyr::group_by(dtime_est) %>% #group datetimes, then calculate weighting effect for each datetime
+    dplyr::summarize(baro_psi = marsInterpolateBaro(baro_psi, smp_id, weight, target_id),
+                     smp_id =  "Interpolated",
+                     neighbors = dplyr::n()) %>%
+    zoo::na.trim(sides = "right") #trim trailing NAs
+  # 
+  # #Initialize Final Series
+  # finalseries <- interpolated_baro
+  # 
+  # 
+  # #Give 5 or 15 minute data as appropriate
+  # if(data_interval == "15 mins"){
+  #   clippedseries <- data.frame(dtime_est = seq.POSIXt(from = start_date, to = end_date + lubridate::days(1), by = data_interval) )
+  #   
+  #   finalseries <- dplyr::filter(finalseries, dtime_est %in% clippedseries$dtime_est)
+  #   baro <- dplyr::filter(baro, dtime_est %in% clippedseries$dtime_est)
+  # }
+  # 
+  # 
+  # #Adding "neighbor" counts and instances to report
+  # neighbors <- dplyr::group_by(finalseries, neighbors) %>%
+  #   dplyr::summarize(count = dplyr::n()) %>%
+  #   magrittr::set_colnames(c("Neighbors", "Count"))
+  # 
+  # ##finalseries is now ready, but return() must happen after plot and markdown are created
+  # 
+  # #Baro Raster Plot
+  # #Get elevations #This has been removed in favor of using distances to sort SMPs on plot. Code is left in case 
+  # #baro_elev <- odbc::dbGetQuery(con, "SELECT * FROM smp_elev") %>% filter(smp_id %in% baro$smp_id)
+  # 
+  # #currently disabled (2/2/21)
+  # 
+  # # #Bind all raw baro data with interpolated data, and add weights
+  # # baro_p <- dplyr::bind_rows(baro, finalseries)
+  # # baro_p <- dplyr::left_join(baro_p, baro_weights, by = "smp_id") 
+  # # 
+  # # #Set NA weights to max weight +1 so interpolated data plots at the top of the chart
+  # # baro_p$weight[is.na(baro_p$weight)] <- max(baro_p$weight)+1
+  # # 
+  # # #Sort SMP IDs by elevation
+  # # baro_p$smp_id <- factor(baro_p$smp_id, levels = unique(baro_p$smp_id[order(baro_p$weight)]))
+  # # 
+  # # #Add year and day for chart
+  # # baro_p %<>% dplyr::mutate("day" = yday_decimal(baro_p$dtime_est),
+  # #                    "year" = lubridate::year(baro_p$dtime_est))
+  # # 
+  # # 
+  # # baro_p$smp_id %<>% as.factor
+  # # 
+  # # #Create baro Raster Chart
+  # # p <- marsBaroRasterPlot(baro_p)
+  # 
+  # 
+  # #Create baro Map
+  # # baro_loc <- smp_loc %>% dplyr::filter(smp_id %in% baro$smp_id)
+  # # rownames(baro_loc) <- NULL
+  # # coords <- baro_loc[c("lon_wgs84", "lat_wgs84")]
+  # # baro_sp <- sp::SpatialPointsDataFrame(coords, data = baro_loc, proj4string = sp::CRS("+proj=longlat +datum=WGS84 +ellps=WGS84 +towgs84=0,0,0"))
+  # # coords <- locus_loc[c("lon_wgs84", "lat_wgs84")]
+  # # smp_sp <- sp::SpatialPointsDataFrame(coords, data = locus_loc, proj4string = sp::CRS("+proj=longlat +datum=WGS84 +ellps=WGS84 +towgs84=0,0,0"))
+  # # baro_map <- mapview::mapview(baro_sp, layer.name = "Baro") + mapview::mapview(smp_sp, color = "red", col.regions = NA, layer.name = "Target SMP")
+  # # 
+  # downloader_folder <- "O:/Watershed Sciences/GSI Monitoring/07 Databases and Tracking Spreadsheets/13 MARS Analysis Database/Scripts/Downloader/Baro Data Downloader"
+  # # downloader_folder_csv <- "\\\\\\\\pwdoows\\\\oows\\\\Watershed Sciences\\\\GSI Monitoring\\07 Databases and Tracking Spreadsheets\\13 MARS Analysis Database\\\\Scripts\\\\Downloader\\\\Baro Data Downloader\\\\"
+  # # 
+  # #render markdown document
+  # #output file and output dir arguments do not work, so file is placed where markdown document is, and moved later
+  # 
+  # #markdown is currently disabled
+  # 
+  # # rmarkdown::render(system.file("rmd", "baro.rmd", package = "pwdgsi"), #find .rmd location on local cpu
+  # #                   params = list(smp_id = target_id,  #input parameters to be passed into markdown body
+  # #                                 start_date = start_date,
+  # #                                 end_date = end_date,
+  # #                                 data_interval = data_interval,
+  # #                                 neighbors = neighbors,
+  # #                                 countNAs = countNAs_t,
+  # #                                 p = p,
+  # #                                 map = baro_map,
+  # #                                 baro_latest_dtime = baro_latest_dtime,
+  # #                                 baro_latest_valid = baro_latest_valid))
+  # 
+  # # #give a new filename and path
+  # # new_filename <- paste0(downloader_folder, "/Reports/", paste(target_id, start_date, "to", end_date, sep = "_"), "_baro_report.html")
+  # # 
+  # # #move file to Baro Data Downloader/Reports folder
+  # # file.rename(from = paste0(system.file("rmd", "baro.html", package = "pwdgsi")),
+  # #             to = new_filename)
+  # # 
+  # # #open html
+  # # browseURL(new_filename)
+  # 
+  # #return Final Series. 
+  # return(finalseries)
+  
+}

--- a/R/old_baro.R
+++ b/R/old_baro.R
@@ -41,7 +41,6 @@ old_baro <- function(con, target_id, start_date, end_date, data_interval = c("5 
 
 
   baro$dtime_est %<>% lubridate::force_tz(tz = "EST")
-  baro
 
   #initialize countNAs_t in case the loop doesn't run. It is passed as a param to markdown so it needs to exist.
   countNAs_t <- 0

--- a/R/old_checksnap.R
+++ b/R/old_checksnap.R
@@ -1,0 +1,138 @@
+old_checksnap <- function(con, smp_id, ow_suffix, request_date){
+  
+  #1 Argument Validation
+  #1.1 Check database connection
+  if(!odbc::dbIsValid(con)){
+    stop("Argument 'con' is not an open ODBC channel")
+  }
+  
+  #1.2 check argument lengths
+  if(length(smp_id) != length(ow_suffix)){
+    stop("smp_id and ow_suffix must be of equal length")
+  }
+  
+  if(length(smp_id) != length(request_date) & length(request_date) != 1){
+    stop("request_date must be a single date, or equal length to smp_id and ow_suffix")
+  }
+  
+  #1.3 Assign today() to 'today'
+  request_date <- stringr::str_replace(request_date, "today", as.character(lubridate::today()))
+  
+  #1.4 Check if smp_id and ow_suffix combination are valid
+  #1.4.1 Create dataframe
+  request_df <- data.frame(smp_id, ow_suffix, request_date, stringsAsFactors = FALSE)
+  
+  #1.4.2 Query fieldwork.tbl_ow and check if each smp id and observation well are there
+  # Initialize dataframe
+  ow_validity <- data.frame(ow_uid = numeric(), 
+                            smp_id =  character(),  
+                            ow_suffix = character(), 
+                            stringsAsFactors = FALSE)
+  
+  # Check if smp_id and ow_suffix are in the MARS table "fieldwork.tbl_ow"
+  # Return matches
+  for(i in 1:length(request_df$smp_id)){
+    ow_valid_check <- odbc::dbGetQuery(con, "SELECT * FROM fieldwork.tbl_ow") %>% dplyr::select(-facility_id) %>%  dplyr::filter(smp_id == request_df$smp_id[i] & ow_suffix == request_df$ow_suffix[i])
+    ow_validity <- dplyr::bind_rows(ow_validity, ow_valid_check)
+  }
+  
+  
+  # Join dates back to observation wells and ow_uids back to request criteria
+  ow_validity %<>% dplyr::left_join(request_df, by = c("smp_id", "ow_suffix")) 
+  request_df_validity <- dplyr::left_join(request_df  %>% dplyr::select(-request_date), ow_validity, by = c("smp_id", "ow_suffix"))
+  
+  #2 Query
+  #2.1 initialize dataframe
+  result <- data.frame("snapshot_uid" = numeric(),
+                       "ow_uid" = numeric(),
+                       "dcia_ft2" = numeric(),
+                       "storage_footprint_ft2" = numeric(), 
+                       "orifice_diam_in" = numeric(),
+                       "infil_footprint_ft2" = numeric(),
+                       "storage_depth_ft" = numeric(),
+                       "lined" = character(), # make logical later 
+                       "surface" = character(),  # make logical later 
+                       "storage_volume_ft3" = numeric(),
+                       "infil_dsg_rate_inhr" = numeric(),
+                       stringsAsFactors = FALSE)
+  
+  
+  #2.2 Run get_arbitrary_snapshot in a loop and bind results
+  for(i in 1:length(ow_validity$smp_id)){
+    snapshot_query <- paste0("SELECT * FROM metrics.fun_get_arbitrary_snapshot('", ow_validity$smp_id[i], "','", ow_validity$ow_suffix[i], "','", ow_validity$request_date[i], "') ORDER BY snapshot_uid DESC LIMIT 1")
+    new_result <- odbc::dbGetQuery(con, snapshot_query)
+    result <- dplyr::bind_rows(result, new_result)
+  }
+  
+  #3 Are the snapshots we have equal to the current GreenIT/PlanReview values!?
+  
+  #3.0.5 Where are we looking?
+  table_query <- paste0('select smp_id, \'viw_planreview_crosstab_snapshot\' as location from external.tbl_planreview_crosstab
+                         where smp_id IN (\'',paste(ow_validity$smp_id, collapse = "', '"),'\')  
+                         UNION
+                         select smp_id, \'viw_greenit_unified\' as location from external.viw_greenit_unified
+                         where  smp_id IN (\'',paste(ow_validity$smp_id, collapse = "', '"),'\')')
+  
+  check_table <- odbc::dbGetQuery(con, table_query)
+  
+  
+  #3.1 Let's look at the view greenit unified/planreview crosstab
+  current_values <- data.frame("ow_uid" = numeric(),
+                               "dcia_ft2" = numeric(),
+                               "storage_footprint_ft2" = numeric(), 
+                               "orifice_diam_in" = numeric(),
+                               "infil_footprint_ft2" = numeric(),
+                               "storage_depth_ft" = numeric(),
+                               "lined" = character(), # make logical later 
+                               "surface" = character(),  # make logical later 
+                               "storage_volume_ft3" = numeric(),
+                               "infil_dsg_rate_inhr" = numeric(),
+                               stringsAsFactors = FALSE)
+  
+  # change the query based on the smp chosen
+  for(i in 1:nrow(check_table)){
+    current_values_query <- paste0("SELECT * FROM external.", check_table$location[i]," where smp_id IN ('",check_table$smp_id[i],"')")
+    current_value <- odbc::dbGetQuery(con, current_values_query)
+    current_values <- dplyr::bind_rows(current_values, current_value)
+  }
+  
+  
+  #3.2 Now let's compare between the two for differences
+  comp_fields <- c("ow_uid", "dcia_ft2", "storage_footprint_ft2",
+                   "orifice_diam_in", "infil_footprint_ft2", "storage_depth_ft",
+                   "lined", "surface", "storage_volume_ft3", "infil_dsg_rate_inhr")
+  
+  comp_values <- current_values %>% dplyr::select(all_of(comp_fields)) %>% arrange(ow_uid)
+  comp_result <- result %>% dplyr::select(all_of(comp_fields)) %>% arrange(ow_uid)
+  
+  # let's compare
+  for(i in length(comp_result$ow_uid)){
+    result_hash <- digest::digest(comp_result[i,], algo = "md5")
+    value_hash <- digest::digest(comp_values[i,], algo = "md5")  
+    
+    if(result_hash != value_hash){
+      
+      smp_id_x <- ow_validity$smp_id[ow_validity$ow_uid == comp_result$ow_uid[i]]
+      suffix_x <- ow_validity$ow_suffix[ow_validity$ow_uid == comp_result$ow_uid[i]]
+      
+      #new snapshot entry dbSendQuery, complete tonight/tomorrow
+      update_query <- paste0("select * from metrics.fun_insert_snapshot('",smp_id_x,"', '",suffix_x,"')")
+      dbGetQuery(con, update_query)
+    }
+    
+  }
+  
+  
+  #4 Join results to original request df
+  #4.1 not.na function
+  not.na <- function(x){
+    !is.na(x)
+  }
+  
+  #4.2 turn it into a bool
+  result_bool <- request_df_validity %>% dplyr::left_join(result, by = "ow_uid") %>%
+    dplyr::select(snapshot_uid) %>% not.na() %>% as.vector
+  
+  return(result_bool)
+  
+}

--- a/R/old_events.R
+++ b/R/old_events.R
@@ -1,0 +1,47 @@
+old_events <- function(con, target_id, source = c("gage", "radar"), start_date, end_date){
+  #1 Argument validation
+  #1.1 Check database connection
+  if(!odbc::dbIsValid(con)){
+    stop("Argument 'con' is not an open ODBC channel")
+  }
+  
+  #Sanitize start and end date
+  start_date %<>% as.POSIXct(format = '%Y-%m-%d')
+  end_date %<>% as.POSIXct(format = '%Y-%m-%d')
+  
+  # Was a string supplied to source?
+  if( isTRUE(all.equal(source, c("gage","radar"))) ){
+    stop("No argument supplied for 'source'. Provide a string of either 'gage' or 'radar'")
+  }
+  
+  #Are we working with gages or radarcells?
+  if(source == "gage" | source == "gauge"){
+    rainparams <- data.frame(smptable = "admin.tbl_smp_gage", eventtable = "data.tbl_gage_event", uidvar = "gage_uid", loctable = "admin.tbl_gage", eventuidvar = "gage_event_uid", stringsAsFactors=FALSE)
+  } else if(source == "radar"){
+    rainparams <- data.frame(smptable = "admin.tbl_smp_radar", eventtable = "data.tbl_radar_event", uidvar = "radar_uid", loctable = "admin.tbl_radar", eventuidvar = "radar_event_uid", stringsAsFactors=FALSE)
+  } else { #Parameter is somehow invalid
+    stop("Argument 'source' is not one of 'gage' or 'radar'")
+  }
+  
+  
+  #2 Get closest rain source
+  rainsource <- odbc::dbGetQuery(con, paste0("SELECT * FROM ", rainparams$smptable)) %>% 
+    dplyr::filter(smp_id == target_id) %>%
+    dplyr::pull(rainparams$uidvar)
+  
+  #2.1 Query event data
+  event_query <- paste(paste0("SELECT * FROM ", rainparams$eventtable),
+                       "WHERE", rainparams$uidvar, "= CAST('", rainsource, "' as int)",
+                       "AND eventdatastart_edt >= Date('", start_date, "')",
+                       "AND eventdataend_edt <= Date('", end_date + lubridate::days(1), "');")
+  
+  events <- odbc::dbGetQuery(con, event_query) 
+  # # making this "EST"
+  # events %<>% dplyr::mutate(eventdatastart_est = lubridate::force_tz(eventdatastart_edt,"EST"))
+  # events %<>% dplyr::mutate(eventdataend_est = lubridate::force_tz(eventdataend_edt,"EST"))
+  # events %<>% dplyr::select(-eventdatastart_edt,
+  #                           -eventdataend_edt)
+  # 
+  # #3 return event data
+  # return(events)
+}

--- a/R/old_events.R
+++ b/R/old_events.R
@@ -1,51 +1,3 @@
-<<<<<<< HEAD
-old_events <- function(con, target_id, source = c("gage", "radar"), start_date, end_date){
-  #1 Argument validation
-  #1.1 Check database connection
-  if(!odbc::dbIsValid(con)){
-    stop("Argument 'con' is not an open ODBC channel")
-  }
-  
-  #Sanitize start and end date
-  start_date %<>% as.POSIXct(format = '%Y-%m-%d')
-  end_date %<>% as.POSIXct(format = '%Y-%m-%d')
-  
-  # Was a string supplied to source?
-  if( isTRUE(all.equal(source, c("gage","radar"))) ){
-    stop("No argument supplied for 'source'. Provide a string of either 'gage' or 'radar'")
-  }
-  
-  #Are we working with gages or radarcells?
-  if(source == "gage" | source == "gauge"){
-    rainparams <- data.frame(smptable = "admin.tbl_smp_gage", eventtable = "data.tbl_gage_event", uidvar = "gage_uid", loctable = "admin.tbl_gage", eventuidvar = "gage_event_uid", stringsAsFactors=FALSE)
-  } else if(source == "radar"){
-    rainparams <- data.frame(smptable = "admin.tbl_smp_radar", eventtable = "data.tbl_radar_event", uidvar = "radar_uid", loctable = "admin.tbl_radar", eventuidvar = "radar_event_uid", stringsAsFactors=FALSE)
-  } else { #Parameter is somehow invalid
-    stop("Argument 'source' is not one of 'gage' or 'radar'")
-  }
-  
-  
-  #2 Get closest rain source
-  rainsource <- odbc::dbGetQuery(con, paste0("SELECT * FROM ", rainparams$smptable)) %>% 
-    dplyr::filter(smp_id == target_id) %>%
-    dplyr::pull(rainparams$uidvar)
-  
-  #2.1 Query event data
-  event_query <- paste(paste0("SELECT * FROM ", rainparams$eventtable),
-                       "WHERE", rainparams$uidvar, "= CAST('", rainsource, "' as int)",
-                       "AND eventdatastart_edt >= Date('", start_date, "')",
-                       "AND eventdataend_edt <= Date('", end_date + lubridate::days(1), "');")
-  
-  events <- odbc::dbGetQuery(con, event_query) 
-  # # making this "EST"
-  # events %<>% dplyr::mutate(eventdatastart_est = lubridate::force_tz(eventdatastart_edt,"EST"))
-  # events %<>% dplyr::mutate(eventdataend_est = lubridate::force_tz(eventdataend_edt,"EST"))
-  # events %<>% dplyr::select(-eventdatastart_edt,
-  #                           -eventdataend_edt)
-  # 
-  # #3 return event data
-  # return(events)
-=======
 old_events <- function(dtime_est, rainfall_in, 
                              #DEFAULT VALUES
                              iet_hr = 6, mindepth_in = 0.10) {
@@ -120,5 +72,4 @@ old_events <- function(dtime_est, rainfall_in,
                   event_id)
   
   return(output$event_id)
->>>>>>> 82503c4e81fae4af26c9b0e06c24bcdd13ed1770
 }

--- a/R/old_fetchEvents.R
+++ b/R/old_fetchEvents.R
@@ -1,0 +1,47 @@
+old_fetchEvents <-  function(con, target_id, source = c("gage", "radar"), start_date, end_date){
+  #1 Argument validation
+  #1.1 Check database connection
+  if(!odbc::dbIsValid(con)){
+    stop("Argument 'con' is not an open ODBC channel")
+  }
+  
+  #Sanitize start and end date
+  start_date %<>% as.POSIXct(format = '%Y-%m-%d')
+  end_date %<>% as.POSIXct(format = '%Y-%m-%d')
+  
+  # Was a string supplied to source?
+  if( isTRUE(all.equal(source, c("gage","radar"))) ){
+    stop("No argument supplied for 'source'. Provide a string of either 'gage' or 'radar'")
+  }
+  
+  #Are we working with gages or radarcells?
+  if(source == "gage" | source == "gauge"){
+    rainparams <- data.frame(smptable = "admin.tbl_smp_gage", eventtable = "data.tbl_gage_event", uidvar = "gage_uid", loctable = "admin.tbl_gage", eventuidvar = "gage_event_uid", stringsAsFactors=FALSE)
+  } else if(source == "radar"){
+    rainparams <- data.frame(smptable = "admin.tbl_smp_radar", eventtable = "data.tbl_radar_event", uidvar = "radar_uid", loctable = "admin.tbl_radar", eventuidvar = "radar_event_uid", stringsAsFactors=FALSE)
+  } else { #Parameter is somehow invalid
+    stop("Argument 'source' is not one of 'gage' or 'radar'")
+  }
+  
+  
+  #2 Get closest rain source
+  rainsource <- odbc::dbGetQuery(con, paste0("SELECT * FROM ", rainparams$smptable)) %>% 
+    dplyr::filter(smp_id == target_id) %>%
+    dplyr::pull(rainparams$uidvar)
+  
+  #2.1 Query event data
+  event_query <- paste(paste0("SELECT * FROM ", rainparams$eventtable),
+                       "WHERE", rainparams$uidvar, "= CAST('", rainsource, "' as int)",
+                       "AND eventdatastart_edt >= Date('", start_date, "')",
+                       "AND eventdataend_edt <= Date('", end_date + lubridate::days(1), "');")
+  
+  events <- odbc::dbGetQuery(con, event_query) 
+  # making this "EST"
+  events %<>% dplyr::mutate(eventdatastart_est = lubridate::force_tz(eventdatastart_edt,"EST"))
+  events %<>% dplyr::mutate(eventdataend_est = lubridate::force_tz(eventdataend_edt,"EST"))
+  events %<>% dplyr::select(-eventdatastart_edt,
+                            -eventdataend_edt)
+  
+  #3 return event data
+  return(events)
+}

--- a/R/old_level.R
+++ b/R/old_level.R
@@ -1,4 +1,4 @@
-old_fetch <- function(con, target_id, ow_suffix, start_date, end_date, sump_correct){
+old_level <- function(con, target_id, ow_suffix, start_date, end_date, sump_correct){
   
   #1 Argument Validation
   #1.1 Check database connection
@@ -12,31 +12,32 @@ old_fetch <- function(con, target_id, ow_suffix, start_date, end_date, sump_corr
   validity_query <- paste0("select * from fieldwork.fun_get_ow_uid('",target_id,"','",ow_suffix,"', NULL)")
   ow_uid <- odbc::dbGetQuery(con, validity_query)
   
-  # #1.3 check if data exists in viw will have a sump. Change sump_correct to FALSE if necessary
-  # 
-  # 
-  # #1.4 Pick which table to query
-  # if(stringr::str_replace(ow_suffix, ".$", "") %in% c("CW", "GW", "PZ")){
-  #   level_table <- "data.tbl_gw_depthdata_raw"
-  # }else if(!(stringr::str_replace(ow_suffix, ".$", "") %in% c("CW", "GW", "PZ")) & sump_correct == TRUE){
-  #   level_table <- "data.viw_ow_leveldata_sumpcorrected"
-  # }else if(!(stringr::str_replace(ow_suffix, ".$", "") %in% c("CW", "GW", "PZ")) & sump_correct == FALSE){
-  #   level_table <- "data.tbl_ow_leveldata_raw"
-  # }
-  # start_date %<>% as.POSIXct(format = '%Y-%m-%d')
-  # end_date %<>% as.POSIXct(format = '%Y-%m-%d')
-  # 
-  # #1.5 Add buffer to requested dates
-  # start_date <- lubridate::round_date(start_date) - lubridate::days(1)
-  # end_date <- lubridate::round_date(end_date) + lubridate::days(1)
-  # 
-  # #2 Query database for level data
-  # leveldata_query <- paste0("select * from ", level_table, "
-  #                               WHERE ow_uid = '", ow_uid, "'
-  #                               AND dtime_est BETWEEN '",start_date,"' AND '", end_date, "'")
-  # 
-  # leveldata <- odbc::dbGetQuery(con, leveldata_query) %>% dplyr::arrange(dtime_est)
-  # 
+  #1.3 check if data exists in viw will have a sump. Change sump_correct to FALSE if necessary
+
+
+  #1.4 Pick which table to query
+  if(stringr::str_replace(ow_suffix, ".$", "") %in% c("CW", "GW", "PZ")){
+    level_table <- "data.tbl_gw_depthdata_raw"
+  }else if(!(stringr::str_replace(ow_suffix, ".$", "") %in% c("CW", "GW", "PZ")) & sump_correct == TRUE){
+    level_table <- "data.viw_ow_leveldata_sumpcorrected"
+  }else if(!(stringr::str_replace(ow_suffix, ".$", "") %in% c("CW", "GW", "PZ")) & sump_correct == FALSE){
+    level_table <- "data.tbl_ow_leveldata_raw"
+  }
+  # Forced to "EST" timezone to match database
+  start_date %<>% as.POSIXct(format = '%Y-%m-%d', tz = "EST")
+  end_date %<>% as.POSIXct(format = '%Y-%m-%d', tz = "EST")
+
+  # 1 .5 Add buffer to requested dates
+  start_date <- lubridate::round_date(start_date) - lubridate::days(1)
+  end_date <- lubridate::round_date(end_date) + lubridate::days(1)
+
+  #2 Query database for level data
+  leveldata_query <- paste0("select * from ", level_table, "
+                                WHERE ow_uid = '", ow_uid, "'
+                                AND dtime_est BETWEEN '",start_date,"' AND '", end_date, "'")
+
+  leveldata <- odbc::dbGetQuery(con, leveldata_query) %>% dplyr::arrange(dtime_est)
+
   # leveldata$dtime_est %<>% lubridate::force_tz(tz = "EST") %>% lubridate::round_date("minute")
   # 
   # #3 Return level data

--- a/R/old_level.R
+++ b/R/old_level.R
@@ -1,0 +1,44 @@
+old_fetch <- function(con, target_id, ow_suffix, start_date, end_date, sump_correct){
+  
+  #1 Argument Validation
+  #1.1 Check database connection
+  if(!odbc::dbIsValid(con)){
+    stop("Argument 'con' is not an open ODBC channel")
+  }
+  
+  
+  #1.2 Check if smp_id and ow_suffix are in the MARS table "ow_validity"
+  # Return match
+  validity_query <- paste0("select * from fieldwork.fun_get_ow_uid('",target_id,"','",ow_suffix,"', NULL)")
+  ow_uid <- odbc::dbGetQuery(con, validity_query)
+  
+  # #1.3 check if data exists in viw will have a sump. Change sump_correct to FALSE if necessary
+  # 
+  # 
+  # #1.4 Pick which table to query
+  # if(stringr::str_replace(ow_suffix, ".$", "") %in% c("CW", "GW", "PZ")){
+  #   level_table <- "data.tbl_gw_depthdata_raw"
+  # }else if(!(stringr::str_replace(ow_suffix, ".$", "") %in% c("CW", "GW", "PZ")) & sump_correct == TRUE){
+  #   level_table <- "data.viw_ow_leveldata_sumpcorrected"
+  # }else if(!(stringr::str_replace(ow_suffix, ".$", "") %in% c("CW", "GW", "PZ")) & sump_correct == FALSE){
+  #   level_table <- "data.tbl_ow_leveldata_raw"
+  # }
+  # start_date %<>% as.POSIXct(format = '%Y-%m-%d')
+  # end_date %<>% as.POSIXct(format = '%Y-%m-%d')
+  # 
+  # #1.5 Add buffer to requested dates
+  # start_date <- lubridate::round_date(start_date) - lubridate::days(1)
+  # end_date <- lubridate::round_date(end_date) + lubridate::days(1)
+  # 
+  # #2 Query database for level data
+  # leveldata_query <- paste0("select * from ", level_table, "
+  #                               WHERE ow_uid = '", ow_uid, "'
+  #                               AND dtime_est BETWEEN '",start_date,"' AND '", end_date, "'")
+  # 
+  # leveldata <- odbc::dbGetQuery(con, leveldata_query) %>% dplyr::arrange(dtime_est)
+  # 
+  # leveldata$dtime_est %<>% lubridate::force_tz(tz = "EST") %>% lubridate::round_date("minute")
+  # 
+  # #3 Return level data
+  # return(leveldata)
+}

--- a/R/old_monitoring.R
+++ b/R/old_monitoring.R
@@ -50,7 +50,7 @@ old_monitoring <- function(con, target_id, ow_suffix, source = c("gage", "radar"
   #3 Add rain events
   if(rain_events == TRUE){
     for(i in 1:length(target_id)){
-      results[["Rain Event Data step"]] <- marsFetchRainEventData(con, target_id[i], source, start_date[i], end_date[i])
+      results[["Rain Event Data step"]] <- old_fetchEvents(con, target_id[i], source, start_date[i], end_date[i])
       start_date[i] <- ifelse(nrow(results$`Rain Event Data step`) > 1,
                               min(results[["Rain Event Data step"]]$eventdatastart_est),
                               start_date[i])
@@ -61,13 +61,13 @@ old_monitoring <- function(con, target_id, ow_suffix, source = c("gage", "radar"
       results[["Rain Event Data step"]] <- NULL
     }
   }
-  
-  
+
+
   if(debug){
     ptm <- proc.time()
   }
-  
-  
+
+
   #4 Add Rainfall
   if(rainfall == TRUE){
     for(i in 1:length(target_id)){
@@ -79,99 +79,98 @@ old_monitoring <- function(con, target_id, ow_suffix, source = c("gage", "radar"
     }
   }
   #####
-  
+
   if(debug){
     print(paste("rainfall_lookup_time:", (proc.time()-ptm)[3]))
   }
-  
+
   if(debug){
     ptm <- proc.time()
   }
-  
+
   #5 Add level data
   if(level == TRUE){
-    
+
     for(i in 1:length(target_id)){
-      results[["Level Data step"]] <- old_level(con, target_id[i], ow_suffix[i], start_date[i], end_date[i], sump_correct) %>% 
+      results[["Level Data step"]] <- old_level(con, target_id[i], ow_suffix[i], start_date[i], end_date[i], sump_correct) %>%
         dplyr::left_join(ow_uid_gage, by = "ow_uid") %>%  #join rain gage uid
         dplyr::select(dtime_est, level_ft, ow_uid, rainparams$uidvar) #remove extra columns
       if(rain_events == TRUE){
         level_data_step <- results[["Level Data step"]] #coerce to data frame
-        
+
         results_event_data <- results[["Rain Event Data"]]
-        
+
         level_data_step <- level_data_step[(!is.na(level_data_step$dtime_est)),]
-        
+
         #select relevant columns from the results
         results_event_data %<>% dplyr::select(rainparams$eventuidvar, rainparams$uidvar, eventdatastart_est)
-        
+
         #join by gage uid and by start time, to give a rainfall gage event uid at the start of each event
-        level_data_step %<>% dplyr::left_join(results_event_data, 
-                                              by = c(rainparams$uidvar, "dtime_est" = "eventdatastart_est"))   
-        
+        level_data_step %<>% dplyr::left_join(results_event_data,
+                                              by = c(rainparams$uidvar, "dtime_est" = "eventdatastart_est"))
+
         #carry event uids forward from event start to start of next event
         level_data_step[[rainparams$eventuidvar]] %<>% zoo::na.locf(na.rm = FALSE)
-        
+
         #isolate event data needed for assuring that the rainfall gage event uid isn't assigned too far past the event end
-        event_data <- results[["Rain Event Data"]]  %>% 
+        event_data <- results[["Rain Event Data"]]  %>%
           dplyr::select(rainparams$eventuidvar, eventdataend_est)
-        
+
         #browser()
-        
+
         #join event end times to level data by event uid
         #check that any dtime that has that event uid does not exceed the end time by greater than three days
         #if it does, reassign NA to event uid
-        level_data_step %<>% dplyr::left_join(event_data, by = rainparams$eventuidvar) %>% 
-          dplyr::mutate(new_event_uid = dplyr::case_when(dtime_est >= (eventdataend_est + lubridate::days(4)) ~ NA_integer_, 
-                                                         TRUE ~ level_data_step[[rainparams$eventuidvar]])) %>% 
-          dplyr::select(-!!rainparams$eventuidvar, -eventdataend_est) %>% 
+        level_data_step %<>% dplyr::left_join(event_data, by = rainparams$eventuidvar) %>%
+          dplyr::mutate(new_event_uid = dplyr::case_when(dtime_est >= (eventdataend_est + lubridate::days(4)) ~ NA_integer_,
+                                                         TRUE ~ level_data_step[[rainparams$eventuidvar]])) %>%
+          dplyr::select(-!!rainparams$eventuidvar, -eventdataend_est) %>%
           dplyr::rename(!!rainparams$eventuidvar := new_event_uid)
-        
-        
+
+
         results[["Level Data step"]] <- NULL
         results[["Level Data step"]] <- level_data_step
       }
-      
+
       results[["Level Data"]] <- dplyr::bind_rows(results[["Level Data"]], results[["Level Data step"]])
       results[["Level Data step"]] <- NULL
     }
   }
-  
+
   if(debug){
     print(paste("level_lookup_time:", (proc.time()-ptm)[3]))
   }
-  
+
   if(debug){
     ptm <- proc.time()
   }
-  
-  #remove incomplete events from level/rainfall/rain event data
+
+
+
+# remove incomplete events from level/rainfall/rain event data
   if(rain_events == TRUE & rainfall == TRUE & level == TRUE){
     test_df_id <- dplyr::full_join(results[["Rainfall Data"]], results[["Level Data"]], by = c("dtime_est", rainparams$eventuidvar, rainparams$uidvar)) %>% #join
-      dplyr::arrange(dtime_est) %>% 
+      dplyr::arrange(dtime_est) %>%
       dplyr::filter(!is.na(rainparams$eventuidvar) & is.na(level_ft)) %>%  #filter events that are not NA and and water level that is not NA
-      dplyr::pull(rainparams$eventuidvar) 
-    
+      dplyr::pull(rainparams$eventuidvar)
+  }
+  
     results[["Level Data"]] %<>% dplyr::filter(!(rainparams$eventuidvar %in% test_df_id))
-    
+  
     # !!sym syntax comes from here: https://stackoverflow.com/questions/49786597/r-dplyr-filter-with-a-dynamic-variable-name
     # Because our variable name is a string, we need to make it evaluate as an R symbol instead of the string
     # choked during recent deployment, going to attempt to use rlang::sym() instead
-    
+  
     #filter out rain data for events that do have corresponding water level data
     results[["Rainfall Data"]] %<>% dplyr::filter((!!rlang::sym(rainparams$eventuidvar) %in% results[["Level Data"]][, rainparams$eventuidvar]))
-    
+  
     #fiter out rain events that no longer have corresponding rainfall data
     results[["Rain Event Data"]] %<>% dplyr::filter((!!rlang::sym(rainparams$eventuidvar) %in% results[["Rainfall Data"]][, rainparams$eventuidvar]))
-    
+  
     if(debug){
       print(paste("filtering_time:", (proc.time()-ptm)[3]))
     }
-    
-  }
   
-  
-  
-  #6 Return results
-  return(results)
+
+return(results)
 }

--- a/R/old_monitoring.R
+++ b/R/old_monitoring.R
@@ -1,0 +1,177 @@
+old_monitoring <- function(con, target_id, ow_suffix, source = c("gage", "radar"), start_date, end_date,
+                                    sump_correct = TRUE, rain_events = TRUE, rainfall = TRUE, level = TRUE, daylight_savings = FALSE,
+                                    debug = FALSE){
+  
+  #1 Argument validation
+  #1.1 Check database connection
+  if(!odbc::dbIsValid(con)){
+    stop("Argument 'con' is not an open ODBC channel")
+  }
+  
+  # Was a string supplied to source?
+  if( isTRUE(all.equal(source, c("gage","radar"))) ){
+    stop("No argument supplied for 'source'. Provide a string of either 'gage/gauge' or 'radar'")
+  }
+  
+  #Are we working with gages or radarcells?
+  if(source == "gage" | source == "gauge"){
+    rainparams <- data.frame(smptable = "admin.tbl_smp_gage", eventtable = "data.tbl_gage_event", uidvar = "gage_uid", loctable = "admin.tbl_gage", eventuidvar = "gage_event_uid", stringsAsFactors=FALSE)
+  } else if(source == "radar"){
+    rainparams <- data.frame(smptable = "admin.tbl_smp_radar", eventtable = "data.tbl_radar_event", uidvar = "radar_uid", loctable = "admin.tbl_radar", eventuidvar = "radar_event_uid", stringsAsFactors=FALSE)
+  } else { #Parameter is somehow invalid
+    stop("Argument 'source' is not one of 'gage' or 'radar'")
+  }
+  
+  #2 Initialize list
+  results <- list()
+  
+  #Get closest gage
+  
+  if(debug){
+    ptm <- proc.time()
+  }
+  
+  smp_rain <- odbc::dbGetQuery(con, paste0("SELECT * FROM ", rainparams$smptable)) %>% dplyr::filter(smp_id %in% target_id)
+  ow_validity <- odbc::dbGetQuery(con, "SELECT * FROM fieldwork.tbl_ow")
+  ow_uid_gage <- ow_validity %>% dplyr::right_join(smp_rain, by = "smp_id")
+  
+  if(debug){
+    print(paste0(source, "_lookup_time: ", (proc.time()-ptm)[3]))
+  }
+  
+  #Set datetime date types
+  start_date %<>% as.POSIXct(format = '%Y-%m-%d')
+  end_date %<>% as.POSIXct(format = '%Y-%m-%d')
+  
+  if(debug){
+    ptm <- print(paste("date_time conversion time:", (proc.time()-ptm)[3]))
+  }
+  
+  #3 Add rain events
+  if(rain_events == TRUE){
+    for(i in 1:length(target_id)){
+      results[["Rain Event Data step"]] <- marsFetchRainEventData(con, target_id[i], source, start_date[i], end_date[i])
+      start_date[i] <- ifelse(nrow(results$`Rain Event Data step`) > 1,
+                              min(results[["Rain Event Data step"]]$eventdatastart_est),
+                              start_date[i])
+      end_date[i] <-  ifelse(nrow(results$`Rain Event Data step`) > 1,
+                             max(results[["Rain Event Data step"]]$eventdatastart_est),
+                             end_date[i])
+      results[["Rain Event Data"]] <- dplyr::bind_rows(results[["Rain Event Data"]], results[["Rain Event Data step"]])
+      results[["Rain Event Data step"]] <- NULL
+    }
+  }
+  
+  
+  if(debug){
+    ptm <- proc.time()
+  }
+  
+  
+  #4 Add Rainfall
+  if(rainfall == TRUE){
+    for(i in 1:length(target_id)){
+      results[["Rainfall Data step"]] <- old_rain(con, target_id[i], source, start_date[i], end_date[i], daylight_savings)
+      start_date[i] <- min(results[["Rainfall Data step"]]$dtime_est - lubridate::days(1), na.rm = TRUE)
+      end_date[i] <- max(results[["Rainfall Data step"]]$dtime_est + lubridate::days(1), na.rm = TRUE)
+      results[["Rainfall Data"]] <- dplyr::bind_rows(results[["Rainfall Data"]], results[["Rainfall Data step"]])
+      results[["Rainfall Data step"]] <- NULL
+    }
+  }
+  #####
+  
+  if(debug){
+    print(paste("rainfall_lookup_time:", (proc.time()-ptm)[3]))
+  }
+  
+  if(debug){
+    ptm <- proc.time()
+  }
+  
+  #5 Add level data
+  if(level == TRUE){
+    
+    for(i in 1:length(target_id)){
+      results[["Level Data step"]] <- old_level(con, target_id[i], ow_suffix[i], start_date[i], end_date[i], sump_correct) %>% 
+        dplyr::left_join(ow_uid_gage, by = "ow_uid") %>%  #join rain gage uid
+        dplyr::select(dtime_est, level_ft, ow_uid, rainparams$uidvar) #remove extra columns
+      if(rain_events == TRUE){
+        level_data_step <- results[["Level Data step"]] #coerce to data frame
+        
+        results_event_data <- results[["Rain Event Data"]]
+        
+        level_data_step <- level_data_step[(!is.na(level_data_step$dtime_est)),]
+        
+        #select relevant columns from the results
+        results_event_data %<>% dplyr::select(rainparams$eventuidvar, rainparams$uidvar, eventdatastart_est)
+        
+        #join by gage uid and by start time, to give a rainfall gage event uid at the start of each event
+        level_data_step %<>% dplyr::left_join(results_event_data, 
+                                              by = c(rainparams$uidvar, "dtime_est" = "eventdatastart_est"))   
+        
+        #carry event uids forward from event start to start of next event
+        level_data_step[[rainparams$eventuidvar]] %<>% zoo::na.locf(na.rm = FALSE)
+        
+        #isolate event data needed for assuring that the rainfall gage event uid isn't assigned too far past the event end
+        event_data <- results[["Rain Event Data"]]  %>% 
+          dplyr::select(rainparams$eventuidvar, eventdataend_est)
+        
+        #browser()
+        
+        #join event end times to level data by event uid
+        #check that any dtime that has that event uid does not exceed the end time by greater than three days
+        #if it does, reassign NA to event uid
+        level_data_step %<>% dplyr::left_join(event_data, by = rainparams$eventuidvar) %>% 
+          dplyr::mutate(new_event_uid = dplyr::case_when(dtime_est >= (eventdataend_est + lubridate::days(4)) ~ NA_integer_, 
+                                                         TRUE ~ level_data_step[[rainparams$eventuidvar]])) %>% 
+          dplyr::select(-!!rainparams$eventuidvar, -eventdataend_est) %>% 
+          dplyr::rename(!!rainparams$eventuidvar := new_event_uid)
+        
+        
+        results[["Level Data step"]] <- NULL
+        results[["Level Data step"]] <- level_data_step
+      }
+      
+      results[["Level Data"]] <- dplyr::bind_rows(results[["Level Data"]], results[["Level Data step"]])
+      results[["Level Data step"]] <- NULL
+    }
+  }
+  
+  if(debug){
+    print(paste("level_lookup_time:", (proc.time()-ptm)[3]))
+  }
+  
+  if(debug){
+    ptm <- proc.time()
+  }
+  
+  #remove incomplete events from level/rainfall/rain event data
+  if(rain_events == TRUE & rainfall == TRUE & level == TRUE){
+    test_df_id <- dplyr::full_join(results[["Rainfall Data"]], results[["Level Data"]], by = c("dtime_est", rainparams$eventuidvar, rainparams$uidvar)) %>% #join
+      dplyr::arrange(dtime_est) %>% 
+      dplyr::filter(!is.na(rainparams$eventuidvar) & is.na(level_ft)) %>%  #filter events that are not NA and and water level that is not NA
+      dplyr::pull(rainparams$eventuidvar) 
+    
+    results[["Level Data"]] %<>% dplyr::filter(!(rainparams$eventuidvar %in% test_df_id))
+    
+    # !!sym syntax comes from here: https://stackoverflow.com/questions/49786597/r-dplyr-filter-with-a-dynamic-variable-name
+    # Because our variable name is a string, we need to make it evaluate as an R symbol instead of the string
+    # choked during recent deployment, going to attempt to use rlang::sym() instead
+    
+    #filter out rain data for events that do have corresponding water level data
+    results[["Rainfall Data"]] %<>% dplyr::filter((!!rlang::sym(rainparams$eventuidvar) %in% results[["Level Data"]][, rainparams$eventuidvar]))
+    
+    #fiter out rain events that no longer have corresponding rainfall data
+    results[["Rain Event Data"]] %<>% dplyr::filter((!!rlang::sym(rainparams$eventuidvar) %in% results[["Rainfall Data"]][, rainparams$eventuidvar]))
+    
+    if(debug){
+      print(paste("filtering_time:", (proc.time()-ptm)[3]))
+    }
+    
+  }
+  
+  
+  
+  #6 Return results
+  return(results)
+}

--- a/R/old_rainfall.R
+++ b/R/old_rainfall.R
@@ -1,0 +1,151 @@
+old_rain <- function(con, target_id, source = c("gage", "radar"), start_date, end_date, daylightsavings){
+  if(!odbc::dbIsValid(con)){
+    stop("Argument 'con' is not an open ODBC channel")
+  }
+  # browser()
+  start_date %<>% as.POSIXct(format = '%Y-%m-%d')
+  end_date %<>% as.POSIXct(format = '%Y-%m-%d')
+  
+  # Was a string supplied to source?
+  if( isTRUE(all.equal(source, c("gage","radar"))) ){
+    stop("No argument supplied for 'source'. Provide a string of either 'gage' or 'radar'")
+  }
+  
+  #Are we working with gages or radarcells?
+  if(source == "gage" | source == "gauge"){
+    rainparams <- data.frame(smptable = "admin.tbl_smp_gage", raintable = "data.viw_gage_rainfall", uidvar = "gage_uid", loctable = "admin.tbl_gage", eventuidvar = "gage_event_uid", stringsAsFactors=FALSE)
+  } else if(source == "radar"){
+    rainparams <- data.frame(smptable = "admin.tbl_smp_radar", raintable = "data.viw_radar_rainfall", uidvar = "radar_uid", loctable = "admin.tbl_radar", eventuidvar = "radar_event_uid", stringsAsFactors=FALSE)
+  } else { #Parameter is somehow invalid
+    stop("Argument 'source' is not one of 'gage' or 'radar'")
+  }
+  
+  #Get closest rainfall source
+  smp_query <- paste0("SELECT * FROM ", rainparams$smptable)
+  #print(smp_query)
+  rainsource <- odbc::dbGetQuery(con, smp_query) %>% dplyr::filter(smp_id == target_id) %>% dplyr::pull(rainparams$uidvar)
+  
+  #Collect gage data
+  #First, get all the relevant data from the closest gage
+  rain_query <- paste(paste0("SELECT *, dtime_edt::varchar as dtime FROM ", rainparams$raintable, " "),
+                      paste0("WHERE ", rainparams$uidvar, " = CAST('", rainsource, "' as int)"),
+                      "AND dtime_edt >= Date('", start_date, "')",
+                      "AND dtime_edt <= Date('", end_date + lubridate::days(1), "');")
+
+  # print(rain_query)
+  rain_temp <- odbc::dbGetQuery(con, rain_query)
+  
+
+  # print(rain_query)
+  rain_temp <- odbc::dbGetQuery(con, rain_query)
+
+  if(nrow(rain_temp) == 0){
+
+    if(lubridate::month(start_date) == lubridate::month(lubridate::today())){
+      stop(paste("Rainfall data appears in the MARS database on about a 5 week delay. \nData for", lubridate::month(start_date, label = TRUE, abbr = FALSE), "should be available in the second week of", lubridate::month(lubridate::today() + lubridate::dmonths(1), label = TRUE, abbr = FALSE)))
+    }
+    stop("There is no data in the database for this date range.")
+  }
+  #
+  rain_temp$rainfall_in %<>% as.numeric
+  rain_temp
+ # rain_temp$dtime_edt %<>% lubridate::ymd_hms(tz = "America/New_York")
+  # we need to reformat dates at midnight because ymd_hms does not know how to handle them
+  # this is actually a base R issue, but it is still dumb
+  # https://github.com/tidyverse/lubridate/issues/1124
+
+rain_temp %<>% dplyr::mutate(dtime_est = lubridate::ymd_hms(dtime, tz = "EST")) %>% dplyr::select(-dtime_edt, -dtime)
+
+  #Apparently, attempting to set the time zone on a datetime that falls squarely on the spring forward datetime
+  #Such as 2005-04-03 02:00:00
+  #Returns NA, because the time is impossible.
+  #I hate this so, so much
+  #To mitigate this, we will strip NA values from the new object
+  # rain_temp %<>% dplyr::filter(!is.na(dtime_edt)) %>% dplyr::arrange(dtime_edt)
+  rain_temp %<>% dplyr::filter(!is.na(dtime_est)) %>% dplyr::arrange(dtime_est)
+
+  #Our water level data is not corrected for daylight savings time. ie it doesn't spring forwards
+  #So we must shift back any datetimes within the DST window
+  #Thankfully, the dst() function returns TRUE if a dtime is within that zone
+  # if(daylightsavings == FALSE){
+  #   dst_index <- lubridate::dst(rain_temp$dtime_edt)
+  #   rain_temp$dtime_edt %<>% lubridate::force_tz("EST") #Assign new TZ without changing dates
+  #   rain_temp$dtime_edt[dst_index] <- rain_temp$dtime_edt[dst_index] - lubridate::hours(1)
+  # }
+  # 
+  # #Punctuate data with zeroes to prevent linear interpolation when plotting
+  # #If the time between data points A and B is greater than 15 minutes (the normal timestep), we must insert a zero 15 minutes after A
+  # #If it's greather than 30 minutes, we must insert a zero 15 minutes before B also
+  # 
+  # #First, create data frame to contain zero fills with same column names as our rain data
+  zeroFills <- rain_temp[0,]
+  #print("Begin zero-filling process")
+  for(i in 1:(nrow(rain_temp) - 1)){
+    # k <- difftime(rain_temp$dtime_edt[i+1], rain_temp$dtime_edt[i], units = "min")
+    k <- difftime(rain_temp$dtime_est[i+1], rain_temp$dtime_est[i], units = "min")
+
+    #If gap is > 15 mins, put a zero 15 minutes after the gap starts
+    if(k > 15){
+
+
+      zeroFillIndex <- nrow(zeroFills)+1
+
+      #Boundaries of the interval to be zeroed
+      boundary.low <- rain_temp$dtime_est[i]
+      boundary.high <- rain_temp$dtime_est[i+1]
+      # boundary.low <- rain_temp$dtime_edt[i]
+      # boundary.high <- rain_temp$dtime_edt[i+1]
+
+      #The zero goes 15 minutes (900 seconds) after the first boundary
+      #Filled by index because R is weird about partially filled data frame rows
+      fill <- boundary.low + lubridate::seconds(900)
+      #these were causing several functions to crash. Need a way to index so this doesn't happen again.
+      zeroFills[zeroFillIndex, 5] <- fill                   #dtime_edt
+      zeroFills[zeroFillIndex, 3] <- 0                      #rainfall_in
+      zeroFills[zeroFillIndex, 2] <- rainsource   #gage_uid or radarcell_uid
+      # browser()
+      # print(paste("Gap-filling event ID. Before:", rain_temp$event[i], "After:", rain_temp$event[i+1]))
+      zeroFills[zeroFillIndex, 5] <- marsGapFillEventID(event_low = rain_temp[i, 5], event_high = rain_temp[i+1, 5]) #event
+
+      #If the boundary is longer than 30 minutes, we need a second zero
+      if(k > 30){
+
+        #This zero goes 15 minutes before the upper boundary
+        fill <- boundary.high - lubridate::seconds(900)
+        zeroFills[zeroFillIndex + 1, 2] <- fill                   #dtime_edt
+        zeroFills[zeroFillIndex + 1, 4] <- 0                      #rainfall_in
+        zeroFills[zeroFillIndex + 1, 3] <- rainsource   #gage_uid or radarcell_uid
+
+        #print(paste("Gap-filling event ID. Before:", rain_temp[i, 5], "After:", rain_temp[i+1, 5]))
+        zeroFills[zeroFillIndex + 1, 5] <- marsGapFillEventID(event_low = rain_temp[i, 5], event_high = rain_temp[i+1, 5]) #event
+
+      }
+
+    }
+  }
+  # 
+  # #Replace UIDs with SMP IDs
+  # rainlocs <- odbc::dbGetQuery(con, paste0("SELECT * FROM ", rainparams$loctable))
+  # finalseries <- dplyr::bind_rows(rain_temp, zeroFills) %>%
+  #   dplyr::left_join(rainlocs, by = rainparams$uidvar) %>%
+  #   dplyr::select(dtime_edt, rainfall_in, rainparams$uidvar, rainparams$eventuidvar) %>%
+  #   dplyr::arrange(dtime_edt)
+  # finalseries <- dplyr::bind_rows(rain_temp, zeroFills) %>%
+  #   dplyr::left_join(rainlocs, by = rainparams$uidvar) %>%
+  #   dplyr::select(dtime_est, rainfall_in, rainparams$uidvar, rainparams$eventuidvar) %>%
+  #   dplyr::arrange(dtime_est)
+
+  # #round date to nearest minute
+  rain_temp$dtime_est %<>% lubridate::round_date("minute")
+  rain_temp
+  # 
+  # #Rename dtime column if we are undoing daylight savings time
+  # # if(daylightsavings == FALSE){
+  # #   finalseries <- finalseries %>%
+  # #     dplyr::mutate(dtime_est = dtime_edt) %>%
+  # #     dplyr::select(-dtime_edt)
+  # #   finalseries <- dplyr::select(finalseries, dtime_est, rainfall_in, rainparams$uidvar, rainparams$eventuidvar)
+  # # }
+  # 
+  # return(finalseries)
+}

--- a/R/old_yday.R
+++ b/R/old_yday.R
@@ -1,0 +1,4 @@
+old_yday <- function(dtime_est){
+  
+  lubridate::yday(dtime_est) + lubridate::hour(dtime_est)/24 + lubridate::minute(dtime_est)/(24*60) + lubridate::second(dtime_est)/(24*60*60)
+}

--- a/test-smpsnap.R
+++ b/test-smpsnap.R
@@ -1,0 +1,40 @@
+library(pool)
+
+# Test production db data 
+conn_old <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "mars_data",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = NULL)
+
+
+old_mars <- old_checksnap(conn_old, "1267-2-1", "CS2", "2024-03-27")
+
+pool::poolClose(conn_old)
+
+
+# sandbox_dtime data
+conn_sand <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "sandbox_dtime",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = NULL)
+
+new_rain_q <- "SELECT dtime, rainfall_in FROM data.tbl_gage_rain WHERE gage_uid = 17 
+AND dtime BETWEEN '2024-03-02 05:00:00' AND '2024-03-02 15:00:00'"
+
+new_rain <- dbGetQuery(conn_sand, new_rain_q)
+
+pool::poolClose(conn_sand)
+
+# Duration with new function
+new_mars <- marsStormPeakIntensity_inhr(new_rain$rainfall_in)
+
+# Same values
+new_mars == old_mars

--- a/test-yday.R
+++ b/test-yday.R
@@ -1,0 +1,10 @@
+library(pool)
+library(pwdgsi)
+
+# Current function
+old_mars <- old_yday(lubridate::ymd_hms("2024-03-01 03:00:00"))
+
+# New function
+new_mars <- yday_decimal(lubridate::ymd_hms("2024-03-01 03:00:00", tz = "America/New_York"))
+
+# Same!

--- a/test_marsFetchBaro.R
+++ b/test_marsFetchBaro.R
@@ -1,0 +1,49 @@
+library(pool)
+
+# Old data is 
+conn_old <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "mars_data",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = "EST")
+
+
+old_mars <- old_baro(con = conn_old, 
+                     target_id = "1267-2-1",
+                     start_date = "2024-03-01",
+                     end_date = "2024-03-31",
+                     data_interval = "15 mins")
+
+pool::poolClose(conn_old)
+
+conn_sand <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "sandbox_dtime",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = NULL)
+
+
+new_mars <- marsFetchBaroData(con = conn_sand, 
+                                  target_id = "1267-2-1",
+                                  start_date = "2024-03-01",
+                                  end_date = "2024-03-31",
+                                  data_interval = "15 mins")
+poolClose(conn_sand)
+
+old_mars <- old_mars |>  
+  dplyr::rename(dtime = dtime_est) |>
+   dplyr::mutate(dtime = lubridate::with_tz(dtime, tz = "America/New_York"))
+   
+diffs <- dplyr::symdiff(new_mars, old_mars)
+
+
+old_10 <- old_mars |> dplyr::filter(dplyr::between(dtime, lubridate::ymd("2024-03-10"), lubridate::ymd("2024-03-11")), smp_id == '9-1-1')
+new_10 <- new_mars |> dplyr::filter(dplyr::between(dtime, lubridate::ymd("2024-03-10"), lubridate::ymd("2024-03-11")), smp_id == '9-1-1')
+
+diffs10 <- dplyr::symdiff(new_10, old_10)

--- a/test_marsFetchBaro.R
+++ b/test_marsFetchBaro.R
@@ -1,6 +1,57 @@
 library(pool)
 
-# Old data is 
+# Test production db data 
+conn_old <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "mars_data",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = "EST")
+
+# Spring forward
+old_mars <- old_baro(con = conn_old, 
+                     target_id = "1267-2-1",
+                     start_date = "2024-03-01",
+                     end_date = "2024-03-31",
+                     data_interval = "15 mins")
+
+pool::poolClose(conn_old)
+
+# sandbox_dtime data
+conn_sand <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "sandbox_dtime",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = NULL)
+
+# Data for spring fowards
+new_mars <- marsFetchBaroData(con = conn_sand, 
+                                  target_id = "1267-2-1",
+                                  start_date = "2024-03-01",
+                                  end_date = "2024-03-31",
+                                  data_interval = "15 mins")
+poolClose(conn_sand)
+
+# Change old data to EDT
+old_mars2 <- old_mars |>  
+  dplyr::rename(dtime = dtime_est) |>
+   dplyr::mutate(dtime = lubridate::with_tz(dtime, tz = "America/New_York"))
+
+# Old function adds an extra day (slightly weird with timezones I think)
+diffs <- dplyr::symdiff(new_mars, old_mars2)
+
+# No diffs for change
+old_10 <- old_mars2 |> dplyr::filter(dplyr::between(dtime, lubridate::ymd("2024-03-10"), lubridate::ymd("2024-03-11")), smp_id == '9-1-1')
+new_10 <- new_mars |> dplyr::filter(dplyr::between(dtime, lubridate::ymd("2024-03-10"), lubridate::ymd("2024-03-11")), smp_id == '9-1-1')
+
+diffs10 <- dplyr::setdiff(old_10, new_10)
+
+
 conn_old <- dbPool(
   drv = RPostgres::Postgres(),
   host = "PWDMARSDBS1",
@@ -13,8 +64,8 @@ conn_old <- dbPool(
 
 old_mars <- old_baro(con = conn_old, 
                      target_id = "1267-2-1",
-                     start_date = "2024-03-01",
-                     end_date = "2024-03-31",
+                     start_date = "2024-10-01",
+                     end_date = "2024-11-30",
                      data_interval = "15 mins")
 
 pool::poolClose(conn_old)
@@ -30,20 +81,22 @@ conn_sand <- dbPool(
 
 
 new_mars <- marsFetchBaroData(con = conn_sand, 
-                                  target_id = "1267-2-1",
-                                  start_date = "2024-03-01",
-                                  end_date = "2024-03-31",
-                                  data_interval = "15 mins")
+                              target_id = "1267-2-1",
+                              start_date = "2024-10-01",
+                              end_date = "2024-11-30",
+                              data_interval = "15 mins")
 poolClose(conn_sand)
 
-old_mars <- old_mars |>  
+old_mars2 <- old_mars |>  
   dplyr::rename(dtime = dtime_est) |>
-   dplyr::mutate(dtime = lubridate::with_tz(dtime, tz = "America/New_York"))
-   
-diffs <- dplyr::symdiff(new_mars, old_mars)
+  dplyr::mutate(dtime = lubridate::with_tz(dtime, tz = "America/New_York"))
+
+diffs <- dplyr::symdiff(new_mars, old_mars2)
 
 
-old_10 <- old_mars |> dplyr::filter(dplyr::between(dtime, lubridate::ymd("2024-03-10"), lubridate::ymd("2024-03-11")), smp_id == '9-1-1')
-new_10 <- new_mars |> dplyr::filter(dplyr::between(dtime, lubridate::ymd("2024-03-10"), lubridate::ymd("2024-03-11")), smp_id == '9-1-1')
+old_10 <- old_mars2 |> dplyr::filter(dplyr::between(dtime, lubridate::ymd("2024-10-01"), lubridate::ymd("2024-11-15")), smp_id == '9-1-1')
+new_10 <- new_mars |> dplyr::filter(dplyr::between(dtime, lubridate::ymd("2024-10-01"), lubridate::ymd("2024-11-15")), smp_id == '9-1-1')
 
-diffs10 <- dplyr::symdiff(new_10, old_10)
+# Same as above
+diffs10 <- dplyr::setdiff(old_10, new_10)
+

--- a/test_marsFetchBaro.R
+++ b/test_marsFetchBaro.R
@@ -94,9 +94,9 @@ old_mars2 <- old_mars |>
 diffs <- dplyr::symdiff(new_mars, old_mars2)
 
 
-old_10 <- old_mars2 |> dplyr::filter(dplyr::between(dtime, lubridate::ymd("2024-10-01"), lubridate::ymd("2024-11-15")), smp_id == '9-1-1')
-new_10 <- new_mars |> dplyr::filter(dplyr::between(dtime, lubridate::ymd("2024-10-01"), lubridate::ymd("2024-11-15")), smp_id == '9-1-1')
+old_10 <- old_mars2 |> dplyr::filter(dplyr::between(dtime, lubridate::ymd("2024-10-01"), lubridate::ymd("2024-11-15")))
+new_10 <- new_mars |> dplyr::filter(dplyr::between(dtime, lubridate::ymd("2024-10-01"), lubridate::ymd("2024-11-15")))
 
 # Same as above
-diffs10 <- dplyr::setdiff(old_10, new_10)
+diffs10 <- dplyr::symdiff(old_10, new_10)
 

--- a/test_marsFetchEvents.R
+++ b/test_marsFetchEvents.R
@@ -1,0 +1,41 @@
+library(pool)
+
+# Test jump forward in March
+conn_old <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "mars_data",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = NULL)
+
+# Current production db
+old_mars <- old_events(con = conn_old, 
+                     target_id = "1267-2-1",
+                     source = "gage",
+                     start_date = "2024-03-01",
+                     end_date = "2024-03-31")
+
+pool::poolClose(conn_old)
+
+conn_sand <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "sandbox_dtime",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = NULL)
+
+# Data from sandbox_dtime
+new_mars <- marsFetchRainEventData(con = conn_sand, 
+                                  target_id = "1267-2-1",
+                                  source = "gage",
+                                  start_date = "2024-03-01",
+                                  end_date = "2024-03-31")
+poolClose(conn_sand)
+
+old_mars1 <- old_mars |>
+  dplyr::rename(eventdatastart = eventdatastart_edt,
+                eventdataend =  eventdataend_edt)

--- a/test_marsFetchEvents.R
+++ b/test_marsFetchEvents.R
@@ -11,7 +11,7 @@ conn_old <- dbPool(
   timezone = NULL)
 
 # Current production db
-old_mars <- old_events(con = conn_old, 
+old_mars <- old_fetchEvents(con = conn_old, 
                      target_id = "1267-2-1",
                      source = "gage",
                      start_date = "2024-03-01",
@@ -37,5 +37,7 @@ new_mars <- marsFetchRainEventData(con = conn_sand,
 poolClose(conn_sand)
 
 old_mars1 <- old_mars |>
-  dplyr::rename(eventdatastart = eventdatastart_edt,
-                eventdataend =  eventdataend_edt)
+  dplyr::rename(eventdatastart = eventdatastart_est,
+                eventdataend =  eventdataend_est)
+# diff between the two is because one 00:00:00 is missing from the old dataset :(
+diffs <- dplyr::symdiff(new_mars, old_mars1)

--- a/test_marsFetchLevel.R
+++ b/test_marsFetchLevel.R
@@ -11,9 +11,9 @@ conn_old <- dbPool(
   timezone = "EST")
 
 # Current production db
-old_mars <- old_level(con = conn_old, 
+old_mars_level <- old_level(con = conn_old, 
                       target_id = "1267-2-1",
-                      ow_suffix = "CS1",
+                      ow_suffix = "CS2",
                       start_date = "2024-03-01",
                       end_date = "2024-03-31",
                       sump_correct = TRUE)

--- a/test_marsFetchLevel.R
+++ b/test_marsFetchLevel.R
@@ -45,7 +45,7 @@ old_mars1 <- old_mars |>
   dplyr::mutate(dtime = lubridate::with_tz(dtime, tzone = "America/New_York"))
 
 # Diffs show only 4/1 days that are likely due to requesting in EST and then coverting to America/New_York
-diffs <- dplyr::symdiff(new_mars |> dplyr::select(dtime, level_ft, smp_id), old_mars1 |> dplyr::select(dtime, level_ft, smp_id))
+diffs <- dplyr::symdiff(new_mars1 |> dplyr::select(dtime, level_ft, smp_id), old_mars1 |> dplyr::select(dtime, level_ft, smp_id))
 
 # Test fall back in November
 conn_old <- dbPool(

--- a/test_marsFetchLevel.R
+++ b/test_marsFetchLevel.R
@@ -1,0 +1,37 @@
+library(pool)
+
+# Test jump forward in March
+conn_old <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "mars_data",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = NULL)
+
+# Current production db
+old_mars <- old_level(con = conn_old, 
+                     target_id = "1267-2-1",
+                     source = "gage",
+                     start_date = "2024-03-01",
+                     end_date = "2024-03-31")
+
+pool::poolClose(conn_old)
+
+conn_sand <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "sandbox_dtime",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = NULL)
+
+# Data from sandbox_dtime
+new_mars <- marsFetchRainfallData(con = conn_sand, 
+                                  target_id = "1267-2-1",
+                                  source = "gage",
+                                  start_date = "2024-03-01",
+                                  end_date = "2024-03-31")
+poolClose(conn_sand)

--- a/test_marsFetchLevel.R
+++ b/test_marsFetchLevel.R
@@ -8,16 +8,18 @@ conn_old <- dbPool(
   dbname = "mars_data",
   user= Sys.getenv("shiny_uid"),
   password = Sys.getenv("shiny_pwd"),
-  timezone = NULL)
+  timezone = "EST")
 
 # Current production db
 old_mars <- old_level(con = conn_old, 
-                     target_id = "1267-2-1",
-                     source = "gage",
-                     start_date = "2024-03-01",
-                     end_date = "2024-03-31")
+                      target_id = "1267-2-1",
+                      ow_suffix = "CS1",
+                      start_date = "2024-03-01",
+                      end_date = "2024-03-31",
+                      sump_correct = TRUE)
 
 pool::poolClose(conn_old)
+
 
 conn_sand <- dbPool(
   drv = RPostgres::Postgres(),
@@ -26,12 +28,68 @@ conn_sand <- dbPool(
   dbname = "sandbox_dtime",
   user= Sys.getenv("shiny_uid"),
   password = Sys.getenv("shiny_pwd"),
-  timezone = NULL)
+  timezone = "America/New_York")
 
 # Data from sandbox_dtime
-new_mars <- marsFetchRainfallData(con = conn_sand, 
+new_mars1 <- marsFetchLevelData(con = conn_sand, 
                                   target_id = "1267-2-1",
-                                  source = "gage",
+                                  ow_suffix = "CS1",
                                   start_date = "2024-03-01",
-                                  end_date = "2024-03-31")
+                                  end_date = "2024-03-31",
+                                  sump_correct = TRUE)
 poolClose(conn_sand)
+
+# Rename and move level data to America/New_York
+old_mars1 <- old_mars |>
+  dplyr::rename(dtime = dtime_est) |>
+  dplyr::mutate(dtime = lubridate::with_tz(dtime, tzone = "America/New_York"))
+
+# Diffs show only 4/1 days that are likely due to requesting in EST and then coverting to America/New_York
+diffs <- dplyr::symdiff(new_mars |> dplyr::select(dtime, level_ft, smp_id), old_mars1 |> dplyr::select(dtime, level_ft, smp_id))
+
+# Test fall back in November
+conn_old <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "mars_data",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = "EST")
+
+# Current production db
+old_mars <- old_level(con = conn_old, 
+                      target_id = "14-1-1",
+                      ow_suffix = "SW1",
+                      start_date = "2024-11-01",
+                      end_date = "2024-11-30",
+                      sump_correct = TRUE)
+
+pool::poolClose(conn_old)
+
+
+conn_sand <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "sandbox_dtime",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = "America/New_York")
+
+# Data from sandbox_dtime
+new_mars <- marsFetchLevelData(con = conn_sand, 
+                                target_id = "14-1-1",
+                                ow_suffix = "SW1",
+                                start_date = "2024-11-01",
+                                end_date = "2024-11-30",
+                                sump_correct = TRUE)
+poolClose(conn_sand)
+
+# Rename and move level data to America/New_York
+old_mars1 <- old_mars |>
+  dplyr::rename(dtime = dtime_est) |>
+  dplyr::mutate(dtime = lubridate::with_tz(dtime, tzone = "America/New_York"))
+
+# Diffs show only 4/1 days that are likely due to requesting in EST and then coverting to America/New_York
+diffs <- dplyr::symdiff(new_mars |> dplyr::select(dtime, level_ft, smp_id), old_mars1 |> dplyr::select(dtime, level_ft, smp_id))

--- a/test_marsFetchMonitor.R
+++ b/test_marsFetchMonitor.R
@@ -1,0 +1,41 @@
+library(pool)
+
+# Test jump forward in March
+conn_old <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "mars_data",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = NULL)
+
+# Current production db
+old_mars <- old_monitoring(con = conn_old, 
+                      target_id = "1267-2-1",
+                      ow_suffix = "CS1",
+                      source = "gauge",
+                      start_date = "2024-03-01",
+                      end_date = "2024-03-31",
+                      sump_correct = TRUE)
+
+pool::poolClose(conn_old)
+
+
+conn_sand <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "sandbox_dtime",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = "America/New_York")
+
+# Data from sandbox_dtime
+new_mars1 <- marsFetchMonitoringData(con = conn_sand, 
+                                target_id = "1267-2-1",
+                                ow_suffix = "CS1",
+                                start_date = "2024-03-01",
+                                end_date = "2024-03-31",
+                                sump_correct = TRUE)
+poolClose(conn_sand)

--- a/test_marsFetchMonitor.R
+++ b/test_marsFetchMonitor.R
@@ -1,4 +1,5 @@
 library(pool)
+library(pwdgsi)
 
 # Test jump forward in March
 conn_old <- dbPool(
@@ -13,7 +14,7 @@ conn_old <- dbPool(
 # Current production db
 old_mars <- old_monitoring(con = conn_old, 
                       target_id = "1267-2-1",
-                      ow_suffix = "CS1",
+                      ow_suffix = "CS2",
                       source = "gauge",
                       start_date = "2024-03-01",
                       end_date = "2024-03-31",
@@ -32,9 +33,10 @@ conn_sand <- dbPool(
   timezone = "America/New_York")
 
 # Data from sandbox_dtime
-new_mars1 <- marsFetchMonitoringData(con = conn_sand, 
+new_mars <- marsFetchMonitoringData(con = conn_sand, 
                                 target_id = "1267-2-1",
-                                ow_suffix = "CS1",
+                                ow_suffix = "CS2",
+                                source = "gauge",
                                 start_date = "2024-03-01",
                                 end_date = "2024-03-31",
                                 sump_correct = TRUE)

--- a/test_marsFetchRainfall.R
+++ b/test_marsFetchRainfall.R
@@ -1,16 +1,16 @@
 library(pool)
 
-# Jump forward in March
+# Test jump forward in March
 conn_old <- dbPool(
   drv = RPostgres::Postgres(),
   host = "PWDMARSDBS1",
-  port = 5434,data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAbElEQVR4Xs2RQQrAMAgEfZgf7W9LAguybljJpR3wEse5JOL3ZObDb4x1loDhHbBOFU6i2Ddnw2KNiXcdAXygJlwE8OFVBHDgKrLgSInN4WMe9iXiqIVsTMjH7z/GhNTEibOxQswcYIWYOR/zAjBJfiXh3jZ6AAAAAElFTkSuQmCC
+  port = 5434,
   dbname = "mars_data",
   user= Sys.getenv("shiny_uid"),
   password = Sys.getenv("shiny_pwd"),
   timezone = NULL)
 
-
+# Current production db
 old_mars <- old_rain(con = conn_old, 
                       target_id = "1267-2-1",
                       source = "gage",
@@ -28,7 +28,7 @@ conn_sand <- dbPool(
   password = Sys.getenv("shiny_pwd"),
   timezone = NULL)
 
-
+# Data from sandbox_dtime
 new_mars <- marsFetchRainfallData(con = conn_sand, 
                                     target_id = "1267-2-1",
                                     source = "gage",
@@ -36,49 +36,56 @@ new_mars <- marsFetchRainfallData(con = conn_sand,
                                     end_date = "2024-03-31")
 poolClose(conn_sand)
 
-# Check to make sure values >DST are different by an hour
+# Manually change old data to be the equivalent of America/New_York (different check from with_tz)
 old_mars <- old_mars |> dplyr::select(dtime_est, gage_uid, rainfall_in) |> 
                  dplyr::rename(dtime = dtime_est) |>
                  dplyr::mutate(dtime = dplyr::if_else(dtime >= lubridate::ymd_hms("2024-03-10 02:00:00", tz = "EST"), 
                                                dtime - lubridate::hours(1), dtime))
 
+# Differences are only midnights which don't exist in production
+diffs <- dplyr::setdiff(new_mars |> dplyr::select(gage_uid, dtime, rainfall_in),
+                        old_mars)
+
+# Check fall back in November
+conn_sand <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "mars_data",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = NULL)
+
+
+old_mars <- old_rain(con = conn_sand,
+                     target_id = "1267-2-1",
+                     source = "gage",
+                     start_date = "2024-10-01",
+                     end_date = "2024-11-30")
+poolClose(conn_sand)
+
+conn_sand <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "sandbox_dtime",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = NULL)
+
+
+new_mars <- marsFetchRainfallData(con = conn_sand,
+                                  target_id = "1267-2-1",
+                                  source = "gage",
+                                  start_date = "2024-10-01",
+                                  end_date = "2024-11-30")
+
+poolClose(conn_sand)
+
+old_mars <- old_mars |> dplyr::select(dtime_est, gage_uid, rainfall_in) |> 
+  dplyr::rename(dtime = dtime_est) |>
+  dplyr::mutate(dtime = dplyr::if_else(dtime <= lubridate::ymd_hms("2024-11-03 02:00:00", tz = "EST"), 
+                                       dtime - lubridate::hours(1), dtime))
 
 diffs <- dplyr::setdiff(new_mars |> dplyr::select(gage_uid, dtime, rainfall_in),
                         old_mars)
-# # Fall back in November
-# conn_sand <- dbPool(
-#   drv = RPostgres::Postgres(),
-#   host = "PWDMARSDBS1",
-#   port = 5434,
-#   dbname = "mars_data",
-#   user= Sys.getenv("shiny_uid"),
-#   password = Sys.getenv("shiny_pwd"),
-#   timezone = NULL)
-# 
-# 
-# old_mars <- old_rain(con = conn_sand, 
-#                      target_id = "1267-2-1",
-#                      source = "gage",
-#                      start_date = "2024-11-01",
-#                      end_date = "2024-11-30")
-# poolClose(conn_sand)
-# 
-# conn_sand <- dbPool(
-#   drv = RPostgres::Postgres(),
-#   host = "PWDMARSDBS1",
-#   port = 5434,
-#   dbname = "sandbox_dtime",
-#   user= Sys.getenv("shiny_uid"),
-#   password = Sys.getenv("shiny_pwd"),
-#   timezone = NULL)
-# 
-# 
-# new_mars <- marsFetchRainfallData(con = conn_sand, 
-#                                   target_id = "1267-2-1",
-#                                   source = "gage",
-#                                   start_date = "2024-11-01",
-#                                   end_date = "2024-11-30")
-# 
-# poolClose(conn_sand)
-# 
-# dplyr::symdiff(new_mars |> dplyr::select(-gage_uid, -gage_event_uid), old_mars |> dplyr::select(-gage_uid, -gage_event_uid))

--- a/test_marsFetchRainfall.R
+++ b/test_marsFetchRainfall.R
@@ -43,7 +43,7 @@ old_mars <- old_mars |> dplyr::select(dtime_est, gage_uid, rainfall_in) |>
                                                dtime - lubridate::hours(1), dtime))
 
 # Differences are only midnights which don't exist in production
-diffs <- dplyr::setdiff(new_mars |> dplyr::select(gage_uid, dtime, rainfall_in),
+diffs <- dplyr::symdiff(new_mars |> dplyr::select(gage_uid, dtime, rainfall_in),
                         old_mars)
 
 # Check fall back in November
@@ -87,5 +87,5 @@ old_mars <- old_mars |> dplyr::select(dtime_est, gage_uid, rainfall_in) |>
   dplyr::mutate(dtime = dplyr::if_else(dtime <= lubridate::ymd_hms("2024-11-03 02:00:00", tz = "EST"), 
                                        dtime - lubridate::hours(1), dtime))
 
-diffs <- dplyr::setdiff(new_mars |> dplyr::select(gage_uid, dtime, rainfall_in),
+diffs <- dplyr::symdiff(new_mars |> dplyr::select(gage_uid, dtime, rainfall_in),
                         old_mars)

--- a/test_marsFetchRainfall.R
+++ b/test_marsFetchRainfall.R
@@ -1,0 +1,84 @@
+library(pool)
+
+# Jump forward in March
+conn_old <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAbElEQVR4Xs2RQQrAMAgEfZgf7W9LAguybljJpR3wEse5JOL3ZObDb4x1loDhHbBOFU6i2Ddnw2KNiXcdAXygJlwE8OFVBHDgKrLgSInN4WMe9iXiqIVsTMjH7z/GhNTEibOxQswcYIWYOR/zAjBJfiXh3jZ6AAAAAElFTkSuQmCC
+  dbname = "mars_data",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = NULL)
+
+
+old_mars <- old_rain(con = conn_old, 
+                      target_id = "1267-2-1",
+                      source = "gage",
+                      start_date = "2024-03-01",
+                      end_date = "2024-03-31")
+
+pool::poolClose(conn_old)
+
+conn_sand <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "sandbox_dtime",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = NULL)
+
+
+new_mars <- marsFetchRainfallData(con = conn_sand, 
+                                    target_id = "1267-2-1",
+                                    source = "gage",
+                                    start_date = "2024-03-01",
+                                    end_date = "2024-03-31")
+poolClose(conn_sand)
+
+# Check to make sure values >DST are different by an hour
+old_mars <- old_mars |> dplyr::select(dtime_est, gage_uid, rainfall_in) |> 
+                 dplyr::rename(dtime = dtime_est) |>
+                 dplyr::mutate(dtime = dplyr::if_else(dtime >= lubridate::ymd_hms("2024-03-10 02:00:00", tz = "EST"), 
+                                               dtime - lubridate::hours(1), dtime))
+
+
+diffs <- dplyr::setdiff(new_mars |> dplyr::select(gage_uid, dtime, rainfall_in),
+                        old_mars)
+# # Fall back in November
+# conn_sand <- dbPool(
+#   drv = RPostgres::Postgres(),
+#   host = "PWDMARSDBS1",
+#   port = 5434,
+#   dbname = "mars_data",
+#   user= Sys.getenv("shiny_uid"),
+#   password = Sys.getenv("shiny_pwd"),
+#   timezone = NULL)
+# 
+# 
+# old_mars <- old_rain(con = conn_sand, 
+#                      target_id = "1267-2-1",
+#                      source = "gage",
+#                      start_date = "2024-11-01",
+#                      end_date = "2024-11-30")
+# poolClose(conn_sand)
+# 
+# conn_sand <- dbPool(
+#   drv = RPostgres::Postgres(),
+#   host = "PWDMARSDBS1",
+#   port = 5434,
+#   dbname = "sandbox_dtime",
+#   user= Sys.getenv("shiny_uid"),
+#   password = Sys.getenv("shiny_pwd"),
+#   timezone = NULL)
+# 
+# 
+# new_mars <- marsFetchRainfallData(con = conn_sand, 
+#                                   target_id = "1267-2-1",
+#                                   source = "gage",
+#                                   start_date = "2024-11-01",
+#                                   end_date = "2024-11-30")
+# 
+# poolClose(conn_sand)
+# 
+# dplyr::symdiff(new_mars |> dplyr::select(-gage_uid, -gage_event_uid), old_mars |> dplyr::select(-gage_uid, -gage_event_uid))

--- a/test_raineventmaint.R
+++ b/test_raineventmaint.R
@@ -1,0 +1,69 @@
+library(pool)
+
+# Test production db data 
+conn_old <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "mars_data",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = NULL) 
+
+old_rain_newdata <- dbGetQuery(conn_old, "select gage_uid, dtime_edt, rainfall_in from data.tbl_gage_rain
+                          WHERE dtime_edt BETWEEN '2024-03-01' AND '2024-03-31'")
+
+
+old_rain_newevents <- old_rain_newdata %>%
+  dplyr::group_by(gage_uid) %>%
+  dplyr::arrange(dtime_edt) %>%
+  dplyr::mutate(event_id = old_events(dtime_edt, rainfall_in)) %>%
+  #Drop the last "complete" event in case it straddles the month boundary
+  #It will get processed the when the next batch of data comes in
+  dplyr::filter(!is.na(event_id), event_id != max(event_id, na.rm = TRUE)) %>%
+  dplyr::group_by(gage_uid, event_id) %>%
+  dplyr::summarize(eventdatastart = dplyr::first(dtime_edt),
+            eventdataend = dplyr::last(dtime_edt),
+            eventduration_hr = old_duration(dtime_edt),
+            eventpeakintensity_inhr = old_peak(dtime_edt, rainfall_in),
+            eventavgintensity_inhr = old_average(dtime_edt, rainfall_in),
+            eventdepth_in = marsStormDepth_in(rainfall_in)) %>%
+  dplyr::select(-event_id)
+
+old_gage17 <- old_rain_newdata |> dplyr::filter(gage_uid == 17)
+old_gage17_filter <- old_gage17 |> dplyr::filter(dplyr::between(dtime_edt, lubridate::ymd_hms("2024-03-27 15:15:00", tz = "America/New_York"),
+                                          lubridate::ymd_hms("2024-03-28 04:30:00", tz = "America/New_York")))
+
+
+conn_sand <- dbPool(
+  drv = RPostgres::Postgres(),
+  host = "PWDMARSDBS1",
+  port = 5434,
+  dbname = "sandbox_dtime",
+  user= Sys.getenv("shiny_uid"),
+  password = Sys.getenv("shiny_pwd"),
+  timezone = NULL)
+
+new_rain_newdata <- dbGetQuery(conn_sand, "select gage_uid, dtime, rainfall_in from data.tbl_gage_rain
+                          WHERE dtime BETWEEN '2024-03-01' AND '2024-03-31'")
+
+
+new_rain_newevents <- new_rain_newdata %>%
+  dplyr::group_by(gage_uid) %>%
+  dplyr::arrange(dtime) %>%
+  dplyr::mutate(event_id = old_events(dtime, rainfall_in)) %>%
+  #Drop the last "complete" event in case it straddles the month boundary
+  #It will get processed the when the next batch of data comes in
+  dplyr::filter(!is.na(event_id), event_id != max(event_id, na.rm = TRUE)) %>%
+  dplyr::group_by(gage_uid, event_id) %>%
+  dplyr::summarize(eventdatastart = dplyr::first(dtime),
+                   eventdataend = dplyr::last(dtime),
+                   eventduration_hr = old_duration(dtime),
+                   eventpeakintensity_inhr = old_peak(dtime, rainfall_in),
+                   eventavgintensity_inhr = old_average(dtime, rainfall_in),
+                   eventdepth_in = marsStormDepth_in(rainfall_in)) %>%
+  dplyr::select(-event_id)
+
+new_gage17 <- new_rain_newdata |> dplyr::filter(gage_uid == 17)
+new_gage17_filter <- new_gage17 |> dplyr::filter(dplyr::between(dtime, lubridate::ymd_hms("2024-03-27 15:15:00", tz = "America/New_York"),
+                                                                lubridate::ymd_hms("2024-03-28 04:30:00", tz = "America/New_York")))


### PR DESCRIPTION
Updated `marsFetchRainfallData` and `marsFetchBaroData` to work with new dtime fields in the database. The functions still live in R/mars_data_fetch_write_functions.R (updated) with the old version living in either R/old_baro.R or R/old_rainfall.R

There are corresponding test files in the PWDGSI project folder, which show that it works both in March and November. These files plus the old_baro.R files will be eventually archived or deleted.

One thing to note, the old functions pull an extra day where the new ones don't. Those will show up on the diff tables

Closes #17 
Closes #19 